### PR TITLE
feat: glass-surface minimap redesign

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,3 +16,10 @@ body {
   height: 100vh;
   overflow: hidden;
 }
+
+/* Minimap viewport indicator — blue-500 at ~30% opacity */
+.react-flow__minimap-mask {
+  stroke: rgba(59, 130, 246, 0.5);
+  stroke-width: 3;
+  fill: rgba(59, 130, 246, 0.1);
+}

--- a/frontend/components/Canvas.tsx
+++ b/frontend/components/Canvas.tsx
@@ -63,8 +63,15 @@ export default function Canvas({
         <Background color="#374151" gap={24} />
         <Controls className="bg-gray-800 border-gray-600" />
         <MiniMap
-          nodeColor={(n) => colorForCategory(n.data?.category ?? "")}
-          className="bg-gray-800 border-gray-600"
+          nodeColor={(n) => colorForCategory(n.data?.category ?? "") + "99"}
+          nodeStrokeColor="transparent"
+          maskColor="rgba(0, 0, 0, 0.75)"
+          className="rounded-xl border border-white/5 shadow-lg shadow-black/30"
+          style={{
+            background: "rgba(0, 0, 0, 0.3)",
+            backdropFilter: "blur(12px)",
+            margin: 8,
+          }}
         />
       </ReactFlow>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the default white/gray MiniMap with a dark blurred glass overlay matching the app's overlay aesthetic
- Category-colored nodes rendered at 60% opacity (`hex + "99"` suffix) — colors remain identifiable without overpowering
- Blue-tinted viewport indicator via `.react-flow__minimap-mask` CSS rule

## Changes
- `frontend/components/Canvas.tsx` — updated `MiniMap` props: `backdropFilter` blur, dark background, rounded corners, transparent node strokes, dark mask outside viewport
- `frontend/app/globals.css` — added `.react-flow__minimap-mask` rule for the SVG viewport rect (blue-500 at 30% fill, 50% stroke)

## Test plan
- [ ] Run `cd frontend && pnpm dev`
- [ ] Send a chat message to populate the canvas with nodes
- [ ] Confirm minimap shows a dark blurred glass background (no white/gray box)
- [ ] Confirm rounded corners and subtle border
- [ ] Confirm node colors are visible but slightly transparent
- [ ] Pan the canvas and confirm a blue-tinted viewport rectangle appears in the minimap
- [ ] Confirm 8px gap from the bottom-right canvas edge

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)