### PR TITLE
feat: canvas node selection & multi-select

### DIFF
--- a/documents/plans/plan-canvas-node-selection.md
+++ b/documents/plans/plan-canvas-node-selection.md
@@ -1,0 +1,103 @@
+# Plan: Canvas Node Selection & Multi-Select (Issue #20)
+
+## Summary
+
+Add single-select, multi-select (Shift+click & drag), Delete key removal, selection info bar, and expose `selectedNodeIds` — all using React Flow's built-in selection APIs plus styleguide-compliant visual feedback.
+
+## Current State
+
+- React Flow already has `elementsSelectable={!readOnly}` enabled
+- ContainerNode shows blue border when selected; ServiceNode has NO selection styling
+- Selection state lives inside React Flow's internal state (via `node.selected`)
+- `useDiagramState` applies `onNodesChange` / `onEdgesChange` from React Flow
+- Canvas edits (remove_node) are sent via WebSocket and trigger Terraform regen
+
+## Design Decisions
+
+1. **Use React Flow's built-in selection** — no custom selection state needed. React Flow already tracks `node.selected` via `onNodesChange` (selection changes come as `NodeChange[]`). Multi-select with Shift+click and drag-select box work out of the box with `selectionOnDrag`.
+2. **Derive `selectedNodeIds`** from `nodes.filter(n => n.selected)` rather than maintaining a parallel array.
+3. **Selection info bar** as a glass-surface overlay on the canvas (like minimap positioning pattern).
+4. **Batch delete** sends one `canvas_edit` per removed node (backend already handles sequential edits).
+
+## Steps
+
+### Step 1: Add selection visual feedback to ServiceNode
+
+**File:** `frontend/components/Canvas/ServiceNode.tsx`
+
+- Accept `selected` prop (React Flow passes it automatically to custom nodes)
+- When selected, add blue glow border using styleguide tokens:
+  - `ring-2 ring-blue-500/50` or box-shadow: `0 0 0 2px rgba(59,130,246,0.5)`
+  - Transition for smooth select/deselect
+
+### Step 2: Improve ContainerNode selection styling
+
+**File:** `frontend/components/Canvas/ContainerNode.tsx`
+
+- Add glow effect matching ServiceNode (currently just changes border color)
+- Use same blue glow shadow for consistency
+
+### Step 3: Enable multi-select features on Canvas
+
+**File:** `frontend/components/Canvas.tsx`
+
+- Add `selectionOnDrag` prop to enable drag-select box
+- Add `multiSelectionKeyCode="Shift"` (React Flow default, but be explicit)
+- Add `deleteKeyCode={null}` — we'll handle delete ourselves for more control
+- Add `selectionMode={SelectionMode.Partial}` so nodes partially inside the box get selected
+
+### Step 4: Add keyboard delete handler
+
+**File:** `frontend/components/Canvas.tsx` (or a new `useCanvasKeyboard.ts` hook if logic exceeds ~30 lines)
+
+- Listen for Delete/Backspace key when canvas is focused
+- Get selected nodes from `nodes.filter(n => n.selected)`
+- For each selected node, send `canvas_edit` remove_node message via WebSocket
+- Remove nodes and their connected edges from local state immediately (optimistic)
+- Only trigger when canvas has focus (not when typing in chat)
+
+### Step 5: Create SelectionInfoBar component
+
+**File:** `frontend/components/Canvas/SelectionInfoBar.tsx`
+
+- Glass surface overlay positioned at bottom-center of canvas
+- Shows: `"{n} items selected"` + trash icon button
+- Trash button triggers same delete logic as keyboard Delete
+- Only visible when `selectedNodeIds.length > 0`
+- Animate in/out with opacity transition
+- Styled per styleguide glass pattern: `bg-black/30 backdrop-blur-md border border-white/5 rounded-xl`
+
+### Step 6: Expose selectedNodeIds
+
+**File:** `frontend/lib/useDiagramState.ts`
+
+- Add computed `selectedNodeIds` derived from nodes state: `nodes.filter(n => n.selected).map(n => n.id)`
+- Export from the hook return value
+- This makes it available to parent page for T12 (chat context)
+
+### Step 7: Wire everything together in page
+
+**File:** `frontend/app/new/page.tsx`
+
+- Pass `selectedNodeIds` where needed
+- Pass delete handler to Canvas (for SelectionInfoBar)
+- Ensure `readOnly` mode disables selection features
+
+## Testing Strategy
+
+- Visual: verify blue glow appears on single-click, multi-select via Shift+click and drag
+- Keyboard: Delete key removes selected nodes
+- Edge cleanup: deleting a node removes its connected edges
+- Deselect: clicking empty canvas clears selection
+- ReadOnly mode: selection disabled when `readOnly=true`
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/components/Canvas/ServiceNode.tsx` | Add selected glow styling |
+| `frontend/components/Canvas/ContainerNode.tsx` | Improve selected glow styling |
+| `frontend/components/Canvas.tsx` | Enable multi-select, wire delete handler, render SelectionInfoBar |
+| `frontend/components/Canvas/SelectionInfoBar.tsx` | **New** — selection count + delete button overlay |
+| `frontend/lib/useDiagramState.ts` | Export `selectedNodeIds` |
+| `frontend/app/new/page.tsx` | Wire selectedNodeIds and delete handler |

--- a/frontend/app/new/page.tsx
+++ b/frontend/app/new/page.tsx
@@ -84,9 +84,11 @@ export default function NewGenerationPage() {
     isChatStreaming,
     chatEnabled,
     chatDisabledReason,
+    selectedNodeIds,
     onNodesChange,
     onEdgesChange,
     handleSend,
+    handleDeleteNodes,
     triggerGeneration,
     isDiscoveryMode,
   } = useCanvasPipeline(
@@ -153,8 +155,10 @@ export default function NewGenerationPage() {
           <Canvas
             nodes={nodes}
             edges={edges}
+            selectedNodeIds={selectedNodeIds}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
+            onDeleteNodes={handleDeleteNodes}
             fitViewTrigger={fitViewTrigger}
           />
           <AgentActivityFeed

--- a/frontend/app/p/[slug]/project-by-slug-client.tsx
+++ b/frontend/app/p/[slug]/project-by-slug-client.tsx
@@ -196,9 +196,11 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
     isChatStreaming,
     chatEnabled,
     chatDisabledReason,
+    selectedNodeIds,
     onNodesChange,
     onEdgesChange,
     handleSend,
+    handleDeleteNodes,
   } = useCanvasPipeline("canvas", canvasSession, handleGenerationComplete, undefined, {
     liveSession: isOwner,
     readOnly: !isOwner,
@@ -333,8 +335,10 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
           <Canvas
             nodes={nodes}
             edges={edges}
+            selectedNodeIds={selectedNodeIds}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
+            onDeleteNodes={handleDeleteNodes}
             fitViewTrigger={fitViewTrigger}
             readOnly={!isOwner}
           />

--- a/frontend/components/Canvas.tsx
+++ b/frontend/components/Canvas.tsx
@@ -5,6 +5,7 @@ import ReactFlow, {
   Controls,
   MiniMap,
   ReactFlowProvider,
+  SelectionMode,
   Node,
   Edge,
   NodeChange,
@@ -18,12 +19,15 @@ import { useEffect, useCallback } from "react";
 import { colorForCategory } from "@/lib/categoryColors";
 import ServiceNode from "@/components/Canvas/ServiceNode";
 import ContainerNode from "@/components/Canvas/ContainerNode";
+import SelectionInfoBar from "@/components/Canvas/SelectionInfoBar";
 
 interface CanvasProps {
   nodes: Node[];
   edges: Edge[];
+  selectedNodeIds: string[];
   onNodesChange: (changes: NodeChange[]) => void;
   onEdgesChange: (changes: EdgeChange[]) => void;
+  onDeleteNodes?: (nodeIds: string[]) => void;
   fitViewTrigger: number;
   readOnly?: boolean;
 }
@@ -31,7 +35,7 @@ interface CanvasProps {
 const nodeTypes = { service: ServiceNode, container: ContainerNode };
 
 function CanvasFlow(props: CanvasProps) {
-  const { nodes, edges, onNodesChange, onEdgesChange, fitViewTrigger, readOnly = false } = props;
+  const { nodes, edges, selectedNodeIds, onNodesChange, onEdgesChange, onDeleteNodes, fitViewTrigger, readOnly = false } = props;
   const { fitView } = useReactFlow();
 
   useEffect(() => {
@@ -49,18 +53,38 @@ function CanvasFlow(props: CanvasProps) {
     [onEdgesChange]
   );
 
+  const handleNodesDelete = useCallback(
+    (deleted: Node[]) => {
+      if (!readOnly && onDeleteNodes) {
+        onDeleteNodes(deleted.map((n) => n.id));
+      }
+    },
+    [readOnly, onDeleteNodes]
+  );
+
+  const handleDeleteSelected = useCallback(() => {
+    if (!readOnly && onDeleteNodes && selectedNodeIds.length > 0) {
+      onDeleteNodes(selectedNodeIds);
+    }
+  }, [readOnly, onDeleteNodes, selectedNodeIds]);
+
   return (
     <ReactFlow
       nodes={nodes}
       edges={edges}
       onNodesChange={readOnly ? undefined : handleNodesChange}
       onEdgesChange={readOnly ? undefined : handleEdgesChange}
+      onNodesDelete={readOnly ? undefined : handleNodesDelete}
       nodeTypes={nodeTypes}
       fitView
       nodesDraggable={!readOnly}
       nodesConnectable={!readOnly}
       elementsSelectable={!readOnly}
-      panOnDrag
+      multiSelectionKeyCode="Shift"
+      selectionOnDrag
+      selectionMode={SelectionMode.Partial}
+      deleteKeyCode={readOnly ? null : ["Delete", "Backspace"]}
+      panOnDrag={[1, 2]}
       zoomOnScroll
       zoomOnPinch
       zoomOnDoubleClick
@@ -82,6 +106,9 @@ function CanvasFlow(props: CanvasProps) {
           margin: 8,
         }}
       />
+      {!readOnly && (
+        <SelectionInfoBar count={selectedNodeIds.length} onDelete={handleDeleteSelected} />
+      )}
     </ReactFlow>
   );
 }

--- a/frontend/components/Canvas/ContainerNode.tsx
+++ b/frontend/components/Canvas/ContainerNode.tsx
@@ -9,8 +9,14 @@ export default function ContainerNode({ data, selected }: { data: ContainerNodeD
   return (
     <div
       data-testid="container-node"
-      style={{ borderColor: borderColor + "99", background: "rgba(59,130,246,0.04)" }}
-      className={`border-2 border-dashed rounded-xl w-full h-full relative ${selected ? 'border-blue-500' : ''}`}
+      className={`border-2 border-dashed rounded-xl w-full h-full relative transition-shadow duration-150 ${selected ? "border-blue-500" : ""}`}
+      style={{
+        borderColor: borderColor + "99",
+        background: "rgba(59,130,246,0.04)",
+        ...(selected
+          ? { boxShadow: "0 0 0 1px rgba(59,130,246,0.3), inset 0 0 20px rgba(59,130,246,0.05)" }
+          : {}),
+      }}
     >
       <div className="absolute top-2 left-3 text-xs font-mono text-blue-400 uppercase tracking-widest">
         {data.label}

--- a/frontend/components/Canvas/SelectionInfoBar.tsx
+++ b/frontend/components/Canvas/SelectionInfoBar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+
+interface SelectionInfoBarProps {
+  count: number;
+  onDelete: () => void;
+}
+
+export default function SelectionInfoBar({ count, onDelete }: SelectionInfoBarProps) {
+  if (count === 0) return null;
+
+  return (
+    <div
+      className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-3 px-4 py-2 rounded-xl border border-white/5 shadow-lg shadow-black/30 transition-opacity duration-200"
+      style={{ background: "rgba(0,0,0,0.3)", backdropFilter: "blur(12px)" }}
+    >
+      <span className="text-sm text-gray-200">
+        {count} {count === 1 ? "item" : "items"} selected
+      </span>
+      <button
+        onClick={onDelete}
+        className="p-1.5 rounded-lg hover:bg-white/10 text-gray-400 hover:text-red-400 transition-colors"
+        aria-label="Delete selected nodes"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 0 1 1.334-1.334h2.666a1.333 1.333 0 0 1 1.334 1.334V4m2 0v9.333a1.333 1.333 0 0 1-1.334 1.334H4.667a1.333 1.333 0 0 1-1.334-1.334V4h9.334Z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/Canvas/ServiceNode.tsx
+++ b/frontend/components/Canvas/ServiceNode.tsx
@@ -10,7 +10,7 @@ type ServiceNodeData = {
   nodeType?: string;
 };
 
-export default function ServiceNode({ data }: { data: ServiceNodeData }) {
+export default function ServiceNode({ data, selected }: { data: ServiceNodeData; selected: boolean }) {
   const color = colorForCategory(data.category);
   const nodeType = data.nodeType ?? deriveNodeType(
     data.label?.toLowerCase().replace(/\s+/g, "_") ?? ""
@@ -19,8 +19,16 @@ export default function ServiceNode({ data }: { data: ServiceNodeData }) {
   return (
     <div
       data-testid="service-node"
-      className="bg-gray-900 rounded-lg p-3 border border-gray-700 w-[100px] flex flex-col items-center gap-2"
-      style={{ borderLeftColor: color, borderLeftWidth: "2px" }}
+      className={`bg-gray-900 rounded-lg p-3 border w-[100px] flex flex-col items-center gap-2 transition-shadow duration-150 ${
+        selected ? "border-blue-500" : "border-gray-700"
+      }`}
+      style={{
+        borderLeftColor: color,
+        borderLeftWidth: "2px",
+        ...(selected
+          ? { boxShadow: "0 0 0 1px rgba(59,130,246,0.3), inset 0 0 20px rgba(59,130,246,0.05)" }
+          : {}),
+      }}
     >
       <Handle type="target" position={Position.Top} className="!bg-gray-500" />
       <div className="flex items-center justify-center">

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -128,7 +128,7 @@ export function useCanvasPipeline(
   options?: CanvasPipelineOptions
 ) {
   const diagram = useDiagramState();
-  const { reset, applyLayout, handleDiagramEvent, hydrate } = diagram;
+  const { reset, applyLayout, handleDiagramEvent, hydrate, nodes } = diagram;
   const liveSession = options?.liveSession ?? false;
   const readOnly = options?.readOnly ?? false;
 
@@ -958,6 +958,27 @@ export function useCanvasPipeline(
     }
   }
 
+  function handleDeleteNodes(nodeIds: string[]) {
+    if (!nodeIds.length) return;
+    const projectId =
+      canvasSession?.mode === "existing"
+        ? canvasSession.project.id
+        : canvasSession?.projectId ?? null;
+    if (!projectId) return;
+
+    for (const id of nodeIds) {
+      void (async () => {
+        const payload = await withAccessToken({
+          type: "canvas_edit",
+          action: "remove_node",
+          id,
+          project_id: projectId,
+        });
+        wsClient.send(payload);
+      })();
+    }
+  }
+
   function handleSend(message: string) {
     if (!chatEnabled) return;
     setMessages((prev) => {
@@ -999,6 +1020,7 @@ export function useCanvasPipeline(
     chatEnabled,
     chatDisabledReason,
     handleSend,
+    handleDeleteNodes,
     triggerGeneration,
     isDiscoveryMode,
   };

--- a/frontend/lib/useDiagramState.ts
+++ b/frontend/lib/useDiagramState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { Node, Edge, NodeChange, EdgeChange, applyNodeChanges, applyEdgeChanges } from "reactflow";
 import { applyDagreLayout } from "@/lib/diagramLayout";
 import { deriveNodeType } from "@/lib/awsIcons";
@@ -145,5 +145,7 @@ export function useDiagramState() {
     setFitViewTrigger((v) => v + 1);
   }, []);
 
-  return { nodes, edges, onNodesChange, onEdgesChange, fitViewTrigger, handleDiagramEvent, reset, applyLayout, hydrate };
+  const selectedNodeIds = useMemo(() => nodes.filter((n) => n.selected).map((n) => n.id), [nodes]);
+
+  return { nodes, edges, selectedNodeIds, onNodesChange, onEdgesChange, fitViewTrigger, handleDiagramEvent, reset, applyLayout, hydrate };
 }


### PR DESCRIPTION
## Summary
- Single-click select with blue glow styling on ServiceNode and ContainerNode (styleguide-compliant)
- Multi-select via Shift+click and drag-select box (`selectionOnDrag`, `SelectionMode.Partial`)
- Delete/Backspace removes selected nodes and sends `canvas_edit` remove_node WS messages for Terraform regen
- Glass-surface `SelectionInfoBar` overlay showing "{n} items selected" + trash button
- Expose `selectedNodeIds` from `useDiagramState` for downstream use (T12 chat context)

Closes #20

## Test plan
- [ ] Click a service node — verify blue glow border appears
- [ ] Click a container node — verify blue glow appears
- [ ] Click empty canvas — verify selection clears
- [ ] Shift+click multiple nodes — verify all get selected
- [ ] Drag-select a region — verify partially-covered nodes get selected
- [ ] With nodes selected, verify info bar shows correct count
- [ ] Press Delete/Backspace — verify nodes removed and edges cleaned up
- [ ] Click trash icon in info bar — verify same delete behavior
- [ ] In read-only shared view — verify selection and delete are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)