### PR TITLE
Fix #64: unify chat-first /p routing, project mode, and budget retry observability

### DIFF
--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -785,6 +785,7 @@ async def _prepare_existing_project_for_run(project_id: str, user_id: str, answe
         user_id,
         {
             "title": derive_project_title(answers),
+            "project_mode": "default",
             "questionnaire_answers": answers if isinstance(answers, dict) else {},
             "nodes": [],
             "edges": [],
@@ -1084,6 +1085,7 @@ async def _start_generation_locked(
             project_id,
             user_id,
             {
+                "project_mode": "default",
                 "generation_status": "queued",
                 "generation_stage": "queued",
                 "generation_error": None,
@@ -1101,6 +1103,7 @@ async def _start_generation_locked(
         project_id,
         user_id,
         {
+            "project_mode": "default",
             "generation_trace_id": trace_id,
             "generation_status": "queued",
             "generation_stage": "queued",

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,8 +17,8 @@ from pydantic import BaseModel
 
 from admin import is_admin_email
 from auth import verify_access_token_user
-from generation_service import GenerationStartError, start_generation_for_user
-from project_store import reset_stale_generations
+from generation_service import GenerationStartError, append_chat_history, start_generation_for_user
+from project_store import create_project_for_generation, get_project_for_user, reset_stale_generations, update_project_fields
 from supabase_client import supabase
 from ws_handler import handle_websocket
 
@@ -122,6 +122,19 @@ class StartGenerationResponse(BaseModel):
     generation_status: str
 
 
+class StartDiscoveryRequest(BaseModel):
+    answers: dict[str, Any]
+    project_id: str | None = None
+    access_token: str | None = None
+    auth_token: str | None = None
+
+
+class StartDiscoveryResponse(BaseModel):
+    project_id: str
+    share_slug: str | None = None
+    generation_status: str
+
+
 class EntitlementsResponse(BaseModel):
     is_admin: bool
 
@@ -159,6 +172,12 @@ def _normalize_generation_answers(raw_answers: Any) -> dict[str, Any]:
         answers = dict(raw_answers)
     answers["regions"] = _normalize_regions(answers)
     answers.pop("region", None)
+    return answers
+
+
+def _normalize_discovery_answers(raw_answers: Any) -> dict[str, Any]:
+    answers = _normalize_generation_answers(raw_answers)
+    answers["_mode"] = "chat_first"
     return answers
 
 
@@ -262,6 +281,71 @@ async def start_generation_endpoint(req: StartGenerationRequest):
         "share_slug": result.get("share_slug") if isinstance(result.get("share_slug"), str) else None,
         "trace_id": str(result["trace_id"]),
         "generation_status": str(result["generation_status"]),
+    }
+
+
+@app.post(
+    "/api/generations/discovery-start",
+    summary="Start or resume discovery mode",
+    description="Creates or reuses a project in discovery mode and returns the canonical share slug for /p/{slug}.",
+    response_model=StartDiscoveryResponse,
+    tags=["generation"],
+)
+async def start_discovery_endpoint(req: StartDiscoveryRequest):
+    token = req.access_token or req.auth_token
+    if not isinstance(token, str) or not token.strip():
+        raise HTTPException(status_code=401, detail={"error": "unauthenticated", "message": "Missing access token."})
+
+    auth_user = await verify_access_token_user(token)
+    if auth_user is None:
+        raise HTTPException(status_code=401, detail={"error": "invalid_token", "message": "Invalid access token."})
+
+    discovery_answers = _normalize_discovery_answers(req.answers)
+
+    try:
+        if req.project_id:
+            try:
+                project_row = await get_project_for_user(req.project_id, auth_user.user_id)
+            except Exception:
+                project_row = await create_project_for_generation(auth_user.user_id, discovery_answers)
+        else:
+            project_row = await create_project_for_generation(auth_user.user_id, discovery_answers)
+
+        project_id = str(project_row.get("id", ""))
+        if not project_id:
+            raise RuntimeError("Project creation returned no ID.")
+
+        await update_project_fields(
+            project_id,
+            auth_user.user_id,
+            {
+                "questionnaire_answers": discovery_answers,
+                "project_mode": "discovery",
+                "generation_status": "idle",
+                "generation_stage": "discovery",
+                "generation_error": None,
+                "generation_trace_id": None,
+                "generation_started_at": None,
+                "generation_completed_at": None,
+                "last_event_at": None,
+            },
+        )
+
+        opening_question = (
+            "Let's design your AWS infrastructure. "
+            "First: what does your application do and who are the main users?"
+        )
+        try:
+            await append_chat_history(project_id, auth_user.user_id, "assistant", opening_question)
+        except Exception:
+            logger.warning("Unable to append discovery opening question project_id=%s", project_id, exc_info=True)
+    except Exception as error:
+        raise HTTPException(status_code=400, detail={"error": "discovery_start_failed", "message": str(error)}) from error
+
+    return {
+        "project_id": project_id,
+        "share_slug": project_row.get("share_slug") if isinstance(project_row.get("share_slug"), str) else None,
+        "generation_status": "idle",
     }
 
 

--- a/backend/project_store.py
+++ b/backend/project_store.py
@@ -75,7 +75,7 @@ def _get_project_for_user_sync(project_id: str, user_id: str) -> dict[str, Any]:
     response = (
         supabase.table("projects")
         .select(
-            "id, user_id, title, questionnaire_answers, nodes, edges, terraform_files, "
+            "id, user_id, title, project_mode, questionnaire_answers, nodes, edges, terraform_files, "
             "cost_estimate, chat_history, description, share_slug, generation_status, "
             "generation_stage, generation_error, generation_trace_id, generation_started_at, "
             "generation_completed_at, last_event_at"
@@ -104,6 +104,7 @@ def _create_project_for_generation_sync(user_id: str, questionnaire_answers: Any
     payload = {
         "user_id": user_id,
         "title": title,
+        "project_mode": "default",
         "questionnaire_answers": answers,
         "nodes": [],
         "edges": [],
@@ -145,7 +146,7 @@ def _create_project_for_generation_sync(user_id: str, questionnaire_answers: Any
         fetched = (
             supabase.table("projects")
             .select(
-                "id, share_slug, title, questionnaire_answers, nodes, edges, terraform_files, "
+                "id, share_slug, title, project_mode, questionnaire_answers, nodes, edges, terraform_files, "
                 "cost_estimate, chat_history, description, generation_status, generation_stage, "
                 "generation_error, generation_trace_id, generation_started_at, generation_completed_at, "
                 "last_event_at"

--- a/backend/tests/test_generation_service_byok.py
+++ b/backend/tests/test_generation_service_byok.py
@@ -54,6 +54,74 @@ async def test_non_admin_start_generation_skips_quota_when_byok_present():
 
 
 @pytest.mark.asyncio
+async def test_start_generation_sets_project_mode_default_for_new_project():
+    def fake_create_task(coro):
+        coro.close()
+        return _FakeTask()
+
+    with patch("generation_service.is_admin_email", return_value=False):
+        with patch(
+            "generation_service.get_user_llm_key",
+            new=AsyncMock(return_value={"provider": "anthropic", "api_key": "sk-test", "model": None}),
+        ):
+            with patch(
+                "generation_service.create_project_for_generation",
+                return_value={"id": "project-123", "share_slug": "slug-123"},
+            ):
+                with patch("generation_service.update_project_fields", new=AsyncMock()) as mock_update:
+                    with patch("generation_service.asyncio.create_task", side_effect=fake_create_task):
+                        await generation_service.start_generation_for_user(
+                            "user-123",
+                            "user@example.com",
+                            SUFFICIENT_ANSWERS,
+                        )
+
+    update_payloads = [call.args[2] for call in mock_update.await_args_list]
+    assert any(payload.get("project_mode") == "default" for payload in update_payloads)
+
+
+@pytest.mark.asyncio
+async def test_start_generation_sets_project_mode_default_for_existing_project():
+    def fake_create_task(coro):
+        coro.close()
+        return _FakeTask()
+
+    existing_row = {
+        "id": "project-123",
+        "share_slug": "slug-123",
+        "nodes": [],
+        "edges": [],
+        "terraform_files": [],
+        "cost_estimate": None,
+        "chat_history": [],
+        "description": None,
+    }
+
+    with patch("generation_service.is_admin_email", return_value=False):
+        with patch(
+            "generation_service.get_user_llm_key",
+            new=AsyncMock(return_value={"provider": "anthropic", "api_key": "sk-test", "model": None}),
+        ):
+            with patch(
+                "generation_service.get_project_for_user",
+                new=AsyncMock(side_effect=[existing_row, existing_row]),
+            ):
+                with patch("generation_service.create_project_for_generation", new=AsyncMock()) as mock_create:
+                    with patch("generation_service.update_project_fields", new=AsyncMock()) as mock_update:
+                        with patch("generation_service.asyncio.create_task", side_effect=fake_create_task):
+                            await generation_service.start_generation_for_user(
+                                "user-123",
+                                "user@example.com",
+                                SUFFICIENT_ANSWERS,
+                                "project-123",
+                            )
+
+    mock_create.assert_not_awaited()
+    update_payloads = [call.args[2] for call in mock_update.await_args_list]
+    assert any(payload.get("project_mode") == "default" for payload in update_payloads)
+
+
+@pytest.mark.asyncio
 async def test_run_generation_passes_llm_creds_for_byok():
     """_run_generation must forward llm_creds to agents when present."""
     class _Runtime:

--- a/backend/tests/test_generation_start_endpoint.py
+++ b/backend/tests/test_generation_start_endpoint.py
@@ -70,6 +70,64 @@ def test_start_generation_surfaces_domain_errors(client):
     assert response.json()["detail"] == {"error": "quota_exhausted", "message": "No quota left"}
 
 
+def test_start_discovery_requires_token(client):
+    response = client.post("/api/generations/discovery-start", json={"answers": {"app_name": "Demo"}})
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "unauthenticated"
+
+
+def test_start_discovery_returns_project_and_slug(client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+    row = {"id": "project-123", "share_slug": "slug-123"}
+
+    with patch("main.verify_access_token_user", return_value=auth_user):
+        with patch("main.create_project_for_generation", new=AsyncMock(return_value=row)) as mock_create:
+            with patch("main.update_project_fields", new=AsyncMock()) as mock_update:
+                with patch("main.append_chat_history", new=AsyncMock()) as mock_append:
+                    response = client.post(
+                        "/api/generations/discovery-start",
+                        json={"answers": {"app_name": "Demo", "regions": ["us-east-1"]}, "access_token": "good-token"},
+                    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "project_id": "project-123",
+        "share_slug": "slug-123",
+        "generation_status": "idle",
+    }
+    mock_create.assert_awaited_once()
+    update_payload = mock_update.await_args.args[2]
+    assert update_payload["project_mode"] == "discovery"
+    assert update_payload["generation_stage"] == "discovery"
+    assert update_payload["questionnaire_answers"]["_mode"] == "chat_first"
+    mock_append.assert_awaited_once()
+
+
+def test_start_discovery_reuses_project_when_owned(client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+    existing_row = {"id": "project-existing", "share_slug": "slug-existing"}
+
+    with patch("main.verify_access_token_user", return_value=auth_user):
+        with patch("main.get_project_for_user", new=AsyncMock(return_value=existing_row)) as mock_get:
+            with patch("main.create_project_for_generation", new=AsyncMock()) as mock_create:
+                with patch("main.update_project_fields", new=AsyncMock()):
+                    with patch("main.append_chat_history", new=AsyncMock()):
+                        response = client.post(
+                            "/api/generations/discovery-start",
+                            json={
+                                "answers": {"app_name": "Demo", "regions": ["us-east-1"]},
+                                "project_id": "project-existing",
+                                "access_token": "good-token",
+                            },
+                        )
+
+    assert response.status_code == 200
+    assert response.json()["project_id"] == "project-existing"
+    mock_get.assert_awaited_once_with("project-existing", "user-123")
+    mock_create.assert_not_awaited()
+
+
 def test_entitlements_requires_authorization_header(client):
     response = client.get("/api/me/entitlements")
 

--- a/backend/tests/test_project_store.py
+++ b/backend/tests/test_project_store.py
@@ -48,6 +48,21 @@ async def test_create_project_for_generation_retries_on_duplicate_slug():
     assert row["share_slug"] == "slug0002"
 
 
+async def test_create_project_for_generation_sets_default_project_mode():
+    insert_chain = _mock_chain([{"id": "p1", "share_slug": "slug0001"}])
+
+    with patch("project_store._generate_slug", return_value="slug0001"):
+        with patch("project_store.supabase") as mock_supabase:
+            insert_table = MagicMock()
+            insert_table.insert.return_value = insert_chain
+            mock_supabase.table.return_value = insert_table
+
+            await project_store.create_project_for_generation("user-1", {"app_name": "Demo"})
+
+    payload = insert_table.insert.call_args.args[0]
+    assert payload["project_mode"] == "default"
+
+
 async def test_update_project_fields_updates_by_id_and_user():
     update_chain = _mock_chain([])
 
@@ -91,3 +106,14 @@ def test_create_project_for_generation_is_coroutine():
 def test_update_project_fields_is_coroutine():
     """BUG-2: update_project_fields must be an async function (coroutine)."""
     assert asyncio.iscoroutinefunction(project_store.update_project_fields)
+
+
+def test_get_project_for_user_selects_project_mode():
+    select_chain = _mock_chain({"id": "project-1", "user_id": "user-1"})
+
+    with patch("project_store.supabase") as mock_supabase:
+        mock_supabase.table.return_value = select_chain
+        project_store._get_project_for_user_sync("project-1", "user-1")
+
+    selected = select_chain.select.call_args.args[0]
+    assert "project_mode" in selected

--- a/backend/tests/test_ws_handler.py
+++ b/backend/tests/test_ws_handler.py
@@ -130,6 +130,7 @@ def test_ws_start_generation_surfaces_start_errors(ws_client):
 def test_ws_subscribe_project_returns_generation_snapshot(ws_client):
     row = {
         "id": "project-1",
+        "project_mode": "discovery",
         "generation_status": "running",
         "generation_stage": "architect",
         "generation_error": None,
@@ -153,6 +154,7 @@ def test_ws_subscribe_project_returns_generation_snapshot(ws_client):
 
     assert data["type"] == "generation_snapshot"
     assert data["project_id"] == "project-1"
+    assert data["project_mode"] == "discovery"
     assert data["generation_status"] == "running"
     assert data["generation_stage"] == "architect"
     mock_subscribe.assert_awaited_once()
@@ -723,6 +725,8 @@ def test_ws_chat_returns_not_ready_when_generation_not_completed(ws_client):
         "terraform_files": [],
         "cost_estimate": None,
         "chat_history": [],
+        "project_mode": "default",
+        "questionnaire_answers": {"_mode": "chat_first", "app_name": "Demo"},
         "generation_status": "completed",
         "generation_stage": "architect",
     }
@@ -955,7 +959,7 @@ def test_chat_discovery_start_does_not_trigger_generation(ws_client):
 
     with patch("ws_handler.verify_access_token_user", return_value=auth_user):
         with patch("ws_handler.create_project_for_generation", new=AsyncMock(return_value=project_row)):
-            with patch("ws_handler.update_project_fields", new=AsyncMock()):
+            with patch("ws_handler.update_project_fields", new=AsyncMock()) as mock_update:
                 with patch("ws_handler.subscribe_websocket", new=AsyncMock()):
                     with patch("ws_handler.append_chat_history", new=AsyncMock()):
                         with patch("ws_handler.start_generation_for_user", new=AsyncMock()) as mock_start:
@@ -978,7 +982,86 @@ def test_chat_discovery_start_does_not_trigger_generation(ws_client):
     assert first["type"] == "project_ready"
     assert second["type"] == "chat_reply"
     assert second["plan_ready"] is False
+    mock_update.assert_awaited_once()
+    update_fields = mock_update.call_args.args[2]
+    assert update_fields["generation_stage"] == "discovery"
+    assert update_fields["project_mode"] == "discovery"
     mock_start.assert_not_awaited()
+
+
+def test_chat_discovery_start_reuses_project_id_when_owned_by_user(ws_client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+    existing_project = {"id": "project-existing", "share_slug": "slug-existing"}
+
+    with patch("ws_handler.verify_access_token_user", return_value=auth_user):
+        with patch("ws_handler.get_project_for_user", new=AsyncMock(return_value=existing_project)) as mock_get:
+            with patch("ws_handler.create_project_for_generation", new=AsyncMock()) as mock_create:
+                with patch("ws_handler.update_project_fields", new=AsyncMock()) as mock_update:
+                    with patch("ws_handler.subscribe_websocket", new=AsyncMock()):
+                        with patch("ws_handler.append_chat_history", new=AsyncMock()):
+                            with ws_client.websocket_connect("/ws") as ws:
+                                ws.send_text(
+                                    json.dumps(
+                                        {
+                                            "type": "chat_discovery_start",
+                                            "project_id": "project-existing",
+                                            "app_name": "Demo",
+                                            "regions": ["us-east-1"],
+                                            "expected_users": "1K–100K/mo",
+                                            "uptime": "99.9% SLA",
+                                            "access_token": "test-token",
+                                        }
+                                    )
+                                )
+                                first = json.loads(ws.receive_text())
+                                second = json.loads(ws.receive_text())
+
+    assert first == {
+        "type": "project_ready",
+        "project_id": "project-existing",
+        "share_slug": "slug-existing",
+    }
+    assert second["type"] == "chat_reply"
+    mock_get.assert_awaited_once_with("project-existing", "user-123")
+    mock_create.assert_not_awaited()
+    mock_update.assert_awaited_once()
+    update_fields = mock_update.call_args.args[2]
+    assert update_fields["generation_stage"] == "discovery"
+    assert update_fields["project_mode"] == "discovery"
+
+
+def test_chat_discovery_start_creates_new_project_when_provided_project_not_owned(ws_client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+    created_project = {"id": "project-new", "share_slug": "slug-new"}
+
+    with patch("ws_handler.verify_access_token_user", return_value=auth_user):
+        with patch("ws_handler.get_project_for_user", new=AsyncMock(side_effect=RuntimeError("Project not found"))) as mock_get:
+            with patch("ws_handler.create_project_for_generation", new=AsyncMock(return_value=created_project)) as mock_create:
+                with patch("ws_handler.update_project_fields", new=AsyncMock()):
+                    with patch("ws_handler.subscribe_websocket", new=AsyncMock()):
+                        with patch("ws_handler.append_chat_history", new=AsyncMock()):
+                            with ws_client.websocket_connect("/ws") as ws:
+                                ws.send_text(
+                                    json.dumps(
+                                        {
+                                            "type": "chat_discovery_start",
+                                            "project_id": "project-not-owned",
+                                            "app_name": "Demo",
+                                            "regions": ["us-east-1"],
+                                            "expected_users": "1K–100K/mo",
+                                            "uptime": "99.9% SLA",
+                                            "access_token": "test-token",
+                                        }
+                                    )
+                                )
+                                first = json.loads(ws.receive_text())
+                                second = json.loads(ws.receive_text())
+
+    assert first["type"] == "project_ready"
+    assert first["project_id"] == "project-new"
+    assert second["type"] == "chat_reply"
+    mock_get.assert_awaited_once_with("project-not-owned", "user-123")
+    mock_create.assert_awaited_once()
 
 
 def test_discovery_chat_message_does_not_trigger_generation_before_approval(ws_client):
@@ -995,8 +1078,9 @@ def test_discovery_chat_message_does_not_trigger_generation_before_approval(ws_c
         "cost_estimate": None,
         "chat_history": [],
         "generation_status": "idle",
-        "generation_stage": "discovery",
-        "questionnaire_answers": {"_mode": "chat_first", "app_name": "Demo"},
+        "generation_stage": "queued",
+        "project_mode": "discovery",
+        "questionnaire_answers": {"app_name": "Demo"},
     }
 
     with patch("ws_handler.verify_access_token_user", return_value=auth_user):

--- a/backend/ws_handler.py
+++ b/backend/ws_handler.py
@@ -111,6 +111,7 @@ async def _send_generation_snapshot(websocket: WebSocket, row: dict[str, Any]) -
         {
             "type": "generation_snapshot",
             "project_id": row.get("id"),
+            "project_mode": row.get("project_mode"),
             "generation_status": row.get("generation_status"),
             "generation_stage": row.get("generation_stage"),
             "generation_error": row.get("generation_error"),
@@ -599,12 +600,15 @@ async def handle_websocket(websocket: WebSocket) -> None:
                     llm_creds = None
 
             generation_stage = project_row.get("generation_stage")
-            questionnaire_answers = project_row.get("questionnaire_answers") or {}
-            is_discovery_mode = (
-                isinstance(questionnaire_answers, dict)
-                and questionnaire_answers.get("_mode") == "chat_first"
+            project_mode = project_row.get("project_mode")
+            questionnaire_answers = project_row.get("questionnaire_answers")
+            if not isinstance(questionnaire_answers, dict):
+                questionnaire_answers = {}
+
+            is_discovery_mode = generation_stage == "discovery" or (
+                project_mode == "discovery" and generation_stage != "completed"
             )
-            if generation_stage not in ("completed", "discovery") and not is_discovery_mode:
+            if generation_stage != "completed" and not is_discovery_mode:
                 if not await _safe_send_json(
                     websocket,
                     {
@@ -1117,8 +1121,16 @@ async def handle_websocket(websocket: WebSocket) -> None:
             if isinstance(monthly_budget, (int, float)) and monthly_budget >= 5:
                 discovery_answers["monthly_budget"] = monthly_budget
 
+            requested_project_id = _project_id_from_message(data)
             try:
-                project_row = await create_project_for_generation(user_id or "", discovery_answers)
+                if requested_project_id:
+                    try:
+                        project_row = await get_project_for_user(requested_project_id, user_id or "")
+                    except Exception:
+                        project_row = await create_project_for_generation(user_id or "", discovery_answers)
+                else:
+                    project_row = await create_project_for_generation(user_id or "", discovery_answers)
+
                 new_project_id = str(project_row.get("id", ""))
                 if not new_project_id:
                     raise ValueError("Project creation returned no ID.")
@@ -1126,6 +1138,8 @@ async def handle_websocket(websocket: WebSocket) -> None:
                     new_project_id,
                     user_id or "",
                     {
+                        "questionnaire_answers": discovery_answers,
+                        "project_mode": "discovery",
                         "generation_status": "idle",
                         "generation_stage": "discovery",
                         "generation_error": None,

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -183,6 +183,7 @@ The projects table persists all diagram state and generation metadata in Supabas
 | `id` | UUID | NO | Primary key, unique per project |
 | `user_id` | UUID | NO | Foreign key to `auth.users(id)` |
 | `title` | TEXT | NO | Project name derived from questionnaire answers |
+| `project_mode` | TEXT | NO | UX mode for project interaction: `default` or `discovery` |
 | `questionnaire_answers` | JSONB | YES | Normalized questionnaire answers for context |
 | `nodes` | JSONB | YES | React Flow nodes array (current diagram state) |
 | `edges` | JSONB | YES | React Flow edges array (current diagram state) |
@@ -205,6 +206,8 @@ The projects table persists all diagram state and generation metadata in Supabas
 **Constraints:**
 - `share_slug` is unique across all projects (enforced at DB level)
 - `user_id` enforces row-level security; users can only access their own projects
+- `project_mode` is constrained to `default` or `discovery`
+- Discovery projects use `project_mode = discovery`; generation start transitions to `project_mode = default`
 - `nodes` and `edges` are always in sync (all edges reference node IDs that exist)
 - `thumbnail_url` is generated asynchronously post-`done` event; may be NULL until thumbnail completes
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -41,13 +41,13 @@ A single-screen form that replaces the old multi-step questionnaire. Two submiss
 
 ### Chat-First Discovery Path (no description)
 1. User fills name + selectors only → clicks "Start Designing"
-2. `canvasSession.mode = "chat_first"` — canvas mounts in discovery mode
-3. Frontend sends `chat_discovery_start` WS message; backend creates project with `generation_stage = "discovery"`
-4. AI sends opening question: *"Let's design your AWS infrastructure. First: what does your application do?"*
+2. Frontend starts a discovery session (reusing `project_id` when available) and resolves `project_id + share_slug`
+3. Frontend redirects immediately to `/p/{share_slug}` (canonical project route)
+4. Project opens in discovery mode (`project_mode = "discovery"`, `generation_stage = "discovery"`)
 5. AI asks questions one at a time (4–6 exchanges), then presents a structured architecture plan
 6. Plan message has `plan_ready: true` → frontend renders **"Accept & Generate"** button below it
 7. Clicking "Accept & Generate" calls `triggerGeneration()` → sends `start_generation` with `conversation_summary`
-8. Normal pipeline runs from this point forward
+8. Generation start transitions project mode to `default`; normal pipeline runs from this point forward
 
 ---
 
@@ -120,6 +120,7 @@ A single-screen form that replaces the old multi-step questionnaire. Two submiss
 | Type | Payload | Description |
 |------|---------|-------------|
 | `project_ready` | `{ project_id, share_slug }` | New project created; frontend should update URL |
+| `generation_snapshot` | `{ project_id, project_mode, generation_status, generation_stage, generation_error, generation_trace_id, generation_started_at, generation_completed_at, last_event_at }` | Snapshot for subscribe/reconnect, including persisted discovery/default mode |
 | `diagram_event` | `{ action: "add_node"\|"add_edge", id, label, category, project_id, trace_id }` | Live canvas update; consumed incrementally |
 | `chat_reply` | `{ message, project_id, plan_ready?: bool }` | Assistant message; `plan_ready: true` triggers "Accept & Generate" button |
 | `chat_reply_delta` | `{ delta, project_id }` | Streaming chunk for assistant message |
@@ -251,6 +252,7 @@ Conducts a structured interview to gather application context before generation.
 |--------|------|-------------|
 | GET | `/health` | Returns `{ "status": "ok" }` |
 | GET | `/health/ready` | Returns 200 when Supabase is reachable; 503 otherwise (load balancer probe) |
+| POST | `/api/generations/discovery-start` | Create or resume a discovery-mode project and return canonical `project_id` + `share_slug` |
 | POST | `/api/generations/start` | Start a new generation (auth required; returns `project_id`, `trace_id`) |
 | GET | `/api/me/entitlements` | Returns `{ is_admin: bool }` for the authenticated user |
 | POST | `/api/llm-key` | Save encrypted BYOK provider key for authenticated user |

--- a/frontend/app/new/page.tsx
+++ b/frontend/app/new/page.tsx
@@ -6,11 +6,14 @@ import PreGenForm from "@/components/PreGenForm";
 import type { PreGenAnswers } from "@/components/PreGenForm/usePreGenForm";
 import { useAuth } from "@/components/auth/useAuth";
 import { fetchUserEntitlements } from "@/lib/entitlements";
-import { startGenerationViaHttp } from "@/lib/generationStart";
+import {
+  resolveProjectRedirectPath,
+  startDiscoverySession,
+  startGenerationViaHttp,
+} from "@/lib/generationStart";
 import { useQuota } from "@/lib/useQuota";
 
 const QUOTA_EXHAUSTED_MESSAGE = "You've used all 5 free beta generations. Paid plans coming soon!";
-const DISCOVERY_DRAFT_STORAGE_KEY = "drawtocloud.discovery.answers.v1";
 const GENERIC_DESCRIPTIONS = new Set(["app", "application", "web app", "mobile app", "saas app", "my app", "demo", "test"]);
 
 function hasSufficientContext(answers: PreGenAnswers): boolean {
@@ -69,17 +72,13 @@ export default function NewGenerationPage() {
       try {
         const needsDiscovery = mode === "chat_first" || !hasSufficientContext(answers);
         if (needsDiscovery) {
-          window.sessionStorage.setItem(DISCOVERY_DRAFT_STORAGE_KEY, JSON.stringify(answers));
-          await router.replace("/new/discovery");
+          const discovery = await startDiscoverySession(answers);
+          await router.replace(resolveProjectRedirectPath(discovery.share_slug));
           return;
         }
 
         const result = await startGenerationViaHttp(answers);
-        if (!result.share_slug) {
-          throw new Error("Server did not return a shareable link.");
-        }
-
-        await router.replace(`/p/${result.share_slug}`);
+        await router.replace(resolveProjectRedirectPath(result.share_slug));
       } catch (error) {
         setSubmitError(error instanceof Error ? error.message : "Failed to start generation.");
       } finally {

--- a/frontend/app/p/[slug]/project-by-slug-client.tsx
+++ b/frontend/app/p/[slug]/project-by-slug-client.tsx
@@ -136,7 +136,8 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
           prev.generationTraceId === mapped.generationTraceId &&
           prev.generationStartedAt === mapped.generationStartedAt &&
           prev.generationCompletedAt === mapped.generationCompletedAt &&
-          prev.lastEventAt === mapped.lastEventAt
+          prev.lastEventAt === mapped.lastEventAt &&
+          prev.projectMode === mapped.projectMode
         ) {
           return prev;
         }
@@ -177,6 +178,7 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
     fitViewTrigger,
     messages,
     pipelineStatus,
+    budgetRetryState,
     terraformFiles,
     costEstimate,
     archDescription,
@@ -204,6 +206,7 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
     handleApprovePlan,
     pendingArchitecturePlanId,
     handleDeleteNodes,
+    isDiscoveryMode,
   } = useCanvasPipeline("canvas", canvasSession, handleGenerationComplete, undefined, {
     liveSession: isOwner,
     readOnly: !isOwner,
@@ -307,7 +310,11 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
         <Chat
           onSend={handleSend}
           onAcceptAndGenerate={handleApprovePlan}
-          approveDisabled={!pendingArchitecturePlanId || isGenerating || !chatEnabled}
+          approveDisabled={
+            isDiscoveryMode
+              ? isGenerating || !chatEnabled
+              : !pendingArchitecturePlanId || isGenerating || !chatEnabled
+          }
           messages={messages}
           disabled={!chatEnabled}
           isTyping={isChatStreaming}
@@ -329,6 +336,7 @@ export default function ProjectBySlugClient({ slug, initialProject }: Props) {
           currentStage={currentStage}
           traceId={traceId}
           lastEventAt={lastEventAt}
+          budgetRetryState={budgetRetryState}
           debugEvents={debugEvents}
           onReconnect={handleReconnect}
           onCopyDebug={copyDebugReport}

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import UserMenu from "@/components/UserMenu";
+import { formatBudgetRetryStatus, type BudgetRetryState } from "@/lib/budgetRetry";
 import type { DebugEvent } from "@/lib/useCanvasPipeline";
 import type { ConnectionState } from "@/lib/websocket";
 
@@ -16,6 +17,7 @@ interface Props {
   currentStage?: string | null;
   traceId?: string | null;
   lastEventAt?: number | null;
+  budgetRetryState?: BudgetRetryState;
   debugEvents?: DebugEvent[];
   onReconnect?: () => void;
   onCopyDebug?: () => void;
@@ -48,6 +50,7 @@ export default function TopBar({
   currentStage = null,
   traceId = null,
   lastEventAt = null,
+  budgetRetryState = undefined,
   debugEvents = [],
   onReconnect,
   onCopyDebug,
@@ -59,6 +62,7 @@ export default function TopBar({
   const [shareNotice, setShareNotice] = useState<string | null>(null);
   const isDone = message?.startsWith("Architecture ready") ?? false;
   const isOwner = mode === "owner";
+  const budgetRetryMessage = budgetRetryState ? formatBudgetRetryStatus(budgetRetryState) : null;
   const quotaLabel = quotaLoading
     ? "Checking quota..."
     : isAdmin
@@ -141,6 +145,19 @@ export default function TopBar({
         <div className="px-4 pb-2 text-xs text-blue-200">{shareNotice}</div>
       )}
 
+      {budgetRetryMessage && (
+        <div
+          className={`px-4 py-2 text-xs text-center ${
+            budgetRetryState?.status === "failed"
+              ? "bg-red-950 text-red-300"
+              : budgetRetryState?.status === "succeeded"
+                ? "bg-emerald-950 text-emerald-300"
+                : "bg-amber-950 text-amber-200"
+          }`}
+        >
+          {budgetRetryMessage}
+        </div>
+      )}
 
       {message && (
         <div

--- a/frontend/lib/__tests__/budgetRetry.test.ts
+++ b/frontend/lib/__tests__/budgetRetry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { INITIAL_BUDGET_RETRY_STATE, formatBudgetRetryStatus, reduceBudgetRetryState } from "../budgetRetry";
+
+describe("budget retry lifecycle state", () => {
+  it("captures retry_started and reports in-progress status", () => {
+    const started = reduceBudgetRetryState(INITIAL_BUDGET_RETRY_STATE, {
+      stage: "budget_cap",
+      event: "retry_started",
+      message: "Estimated monthly cost exceeds hard budget cap; running constrained optimization pass.",
+      details: {
+        budget_cap: 120,
+        estimated_total: 168,
+        overage: 48,
+      },
+      traceId: "trace-start",
+      timestamp: 1_700_000_000_000,
+    });
+
+    expect(started.status).toBe("in_progress");
+    expect(started.budgetCap).toBe(120);
+    expect(started.estimatedTotal).toBe(168);
+    expect(started.overage).toBe(48);
+    expect(formatBudgetRetryStatus(started)).toContain("retry in progress");
+  });
+
+  it("captures retry success with metadata and context", () => {
+    const started = reduceBudgetRetryState(INITIAL_BUDGET_RETRY_STATE, {
+      stage: "budget_cap",
+      event: "retry_started",
+      message: "retry started",
+      details: {
+        budget_cap: 120,
+        estimated_total: 168,
+        overage: 48,
+      },
+      traceId: "trace-1",
+      timestamp: 1_700_000_000_000,
+    });
+
+    const succeeded = reduceBudgetRetryState(started, {
+      stage: "budget_cap",
+      event: "retry_succeeded",
+      message: "Constrained optimization pass satisfied hard budget cap.",
+      details: {
+        budget_cap: 120,
+        estimated_total: 98,
+      },
+      traceId: "trace-1",
+      timestamp: 1_700_000_100_000,
+    });
+
+    expect(succeeded.status).toBe("succeeded");
+    expect(succeeded.budgetCap).toBe(120);
+    expect(succeeded.estimatedTotal).toBe(98);
+    expect(formatBudgetRetryStatus(succeeded)).toContain("trace-1");
+    expect(formatBudgetRetryStatus(succeeded)).toContain("budget_cap.retry_succeeded");
+  });
+
+  it("captures retry failure and overage details", () => {
+    const started = reduceBudgetRetryState(INITIAL_BUDGET_RETRY_STATE, {
+      stage: "budget_cap",
+      event: "retry_started",
+      message: "retry started",
+      details: {
+        budget_cap: 120,
+        estimated_total: 168,
+        overage: 48,
+      },
+      traceId: "trace-2",
+      timestamp: 1_700_000_000_000,
+    });
+
+    const failed = reduceBudgetRetryState(started, {
+      stage: "budget_cap",
+      event: "retry_failed",
+      message: "Estimated monthly cost still exceeds hard budget cap after retry.",
+      details: {
+        budget_cap: 120,
+        estimated_total: 141,
+        overage: 21,
+      },
+      traceId: "trace-2",
+      timestamp: 1_700_000_100_000,
+    });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.budgetCap).toBe(120);
+    expect(failed.estimatedTotal).toBe(141);
+    expect(failed.overage).toBe(21);
+    expect(formatBudgetRetryStatus(failed)).toContain("Budget retry failed");
+  });
+});

--- a/frontend/lib/__tests__/generationStart.test.ts
+++ b/frontend/lib/__tests__/generationStart.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseDiscoveryStartResponse,
+  resolveProjectRedirectPath,
+  shouldFallbackToDiscoveryWs,
+} from "../generationStart";
+
+describe("generation start discovery helpers", () => {
+  it("resolves direct /p/{slug} redirect path", () => {
+    expect(resolveProjectRedirectPath("my-project-slug")).toBe("/p/my-project-slug");
+  });
+
+  it("throws when redirect slug is missing", () => {
+    expect(() => resolveProjectRedirectPath(null)).toThrow("shareable link");
+  });
+
+  it("parses valid discovery start response with trace_id", () => {
+    const parsed = parseDiscoveryStartResponse({
+      project_id: "project-1",
+      share_slug: "my-project-slug",
+      trace_id: "trace-1",
+      generation_status: "idle",
+    });
+
+    expect(parsed).toEqual({
+      project_id: "project-1",
+      share_slug: "my-project-slug",
+      trace_id: "trace-1",
+      generation_status: "idle",
+    });
+  });
+
+  it("parses valid discovery start response without trace_id", () => {
+    const parsed = parseDiscoveryStartResponse({
+      project_id: "project-2",
+      share_slug: "my-project-slug-2",
+      generation_status: "idle",
+    });
+
+    expect(parsed).toEqual({
+      project_id: "project-2",
+      share_slug: "my-project-slug-2",
+      generation_status: "idle",
+    });
+  });
+
+  it("falls back to websocket path for unknown discovery endpoint status", () => {
+    expect(shouldFallbackToDiscoveryWs(404)).toBe(true);
+    expect(shouldFallbackToDiscoveryWs(405)).toBe(true);
+    expect(shouldFallbackToDiscoveryWs(500)).toBe(false);
+  });
+});

--- a/frontend/lib/__tests__/projects.test.ts
+++ b/frontend/lib/__tests__/projects.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mapProjectRow } from "../projects";
+
+describe("mapProjectRow project mode parsing", () => {
+  it("maps explicit discovery mode from backend", () => {
+    const project = mapProjectRow({
+      id: "project-1",
+      title: "Discovery project",
+      project_mode: "discovery",
+      questionnaire_answers: {
+        app_name: "Discovery App",
+      },
+    });
+
+    expect(project).not.toBeNull();
+    expect(project?.projectMode).toBe("discovery");
+  });
+
+  it("defaults to discovery when legacy questionnaire marks chat first", () => {
+    const project = mapProjectRow({
+      id: "project-2",
+      questionnaire_answers: {
+        app_name: "Legacy Discovery App",
+        _mode: "chat_first",
+      },
+    });
+
+    expect(project).not.toBeNull();
+    expect(project?.projectMode).toBe("discovery");
+  });
+
+  it("falls back to default mode when backend value is unknown", () => {
+    const project = mapProjectRow({
+      id: "project-3",
+      project_mode: "something_else",
+      questionnaire_answers: {
+        app_name: "Default App",
+      },
+    });
+
+    expect(project).not.toBeNull();
+    expect(project?.projectMode).toBe("default");
+  });
+});

--- a/frontend/lib/budgetRetry.ts
+++ b/frontend/lib/budgetRetry.ts
@@ -1,0 +1,113 @@
+export type BudgetRetryStatus = "idle" | "in_progress" | "succeeded" | "failed";
+
+export type BudgetRetryState = {
+  status: BudgetRetryStatus;
+  message: string | null;
+  budgetCap: number | null;
+  estimatedTotal: number | null;
+  overage: number | null;
+  stage: string | null;
+  event: string | null;
+  traceId: string | null;
+  updatedAt: number | null;
+};
+
+export type BudgetRetryEventPayload = {
+  stage: string | null;
+  event: string | null;
+  message?: string | null;
+  details?: Record<string, unknown>;
+  traceId?: string | null;
+  timestamp?: number;
+};
+
+export const INITIAL_BUDGET_RETRY_STATE: BudgetRetryState = {
+  status: "idle",
+  message: null,
+  budgetCap: null,
+  estimatedTotal: null,
+  overage: null,
+  stage: null,
+  event: null,
+  traceId: null,
+  updatedAt: null,
+};
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function deriveStatus(current: BudgetRetryStatus, stage: string | null, event: string | null): BudgetRetryStatus {
+  if (stage === "budget_retry") {
+    return current === "idle" ? "in_progress" : current;
+  }
+
+  if (stage !== "budget_cap") return current;
+  if (event === "retry_started") return "in_progress";
+  if (event === "retry_succeeded") return "succeeded";
+  if (event === "retry_failed") return "failed";
+  return current;
+}
+
+function formatCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+export function reduceBudgetRetryState(
+  current: BudgetRetryState,
+  payload: BudgetRetryEventPayload
+): BudgetRetryState {
+  const { stage, event, message, details, traceId, timestamp } = payload;
+  if (stage !== "budget_cap" && stage !== "budget_retry") {
+    return current;
+  }
+
+  const status = deriveStatus(current.status, stage, event);
+  const budgetCap = asFiniteNumber(details?.budget_cap) ?? current.budgetCap;
+  const estimatedTotal = asFiniteNumber(details?.estimated_total) ?? current.estimatedTotal;
+  const overage = asFiniteNumber(details?.overage) ?? current.overage;
+
+  return {
+    status,
+    message: typeof message === "string" && message.trim().length > 0 ? message : current.message,
+    budgetCap,
+    estimatedTotal,
+    overage,
+    stage,
+    event: event ?? current.event,
+    traceId: traceId ?? current.traceId,
+    updatedAt: typeof timestamp === "number" ? timestamp : Date.now(),
+  };
+}
+
+export function formatBudgetRetryStatus(state: BudgetRetryState): string | null {
+  if (state.status === "idle") return null;
+
+  const headline =
+    state.status === "in_progress"
+      ? "Budget retry in progress"
+      : state.status === "succeeded"
+        ? "Budget retry succeeded"
+        : "Budget retry failed";
+
+  const details: string[] = [];
+  if (state.budgetCap !== null) details.push(`cap ${formatCurrency(state.budgetCap)}`);
+  if (state.estimatedTotal !== null) details.push(`estimated ${formatCurrency(state.estimatedTotal)}`);
+  if (state.overage !== null && state.overage > 0) details.push(`overage ${formatCurrency(state.overage)}`);
+
+  const context: string[] = [];
+  if (state.stage && state.event) context.push(`${state.stage}.${state.event}`);
+  else if (state.stage) context.push(state.stage);
+  if (state.traceId) context.push(`trace ${state.traceId}`);
+
+  const parts = [headline];
+  if (details.length > 0) parts.push(details.join(" | "));
+  if (context.length > 0) parts.push(context.join(" | "));
+  if (state.message) parts.push(state.message);
+  return parts.join(" - ");
+}

--- a/frontend/lib/generationStart.ts
+++ b/frontend/lib/generationStart.ts
@@ -1,10 +1,18 @@
-import { getSupabaseBrowserClient } from "@/lib/supabase/browser";
+import { getSupabaseBrowserClient } from "./supabase/browser";
+import wsClient from "./websocket";
 
 export type StartGenerationResponse = {
   project_id: string;
   share_slug: string | null;
   trace_id: string;
   generation_status: string;
+};
+
+export type DiscoveryStartResponse = {
+  project_id: string;
+  share_slug: string | null;
+  generation_status: string;
+  trace_id?: string;
 };
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -17,6 +25,47 @@ export async function withAccessToken(payload: Record<string, unknown>) {
     ...payload,
     access_token: data.session?.access_token,
   };
+}
+
+type ErrorDetail = { detail?: { error?: string; message?: string } };
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function parseErrorMessage(body: unknown): string {
+  const detail = (body as ErrorDetail).detail;
+  if (detail?.message) return detail.message;
+  if (detail?.error) return detail.error;
+  return "Request failed";
+}
+
+export function shouldFallbackToDiscoveryWs(status: number): boolean {
+  return status === 404 || status === 405 || status === 501;
+}
+
+export function parseDiscoveryStartResponse(body: unknown): DiscoveryStartResponse | null {
+  if (!isRecord(body)) return null;
+  if (typeof body.project_id !== "string" || !body.project_id.trim()) return null;
+  if (typeof body.generation_status !== "string" || !body.generation_status.trim()) return null;
+
+  const shareSlug = typeof body.share_slug === "string" && body.share_slug.trim() ? body.share_slug : null;
+  const traceId = typeof body.trace_id === "string" && body.trace_id.trim() ? body.trace_id : undefined;
+
+  return {
+    project_id: body.project_id,
+    share_slug: shareSlug,
+    generation_status: body.generation_status,
+    ...(traceId ? { trace_id: traceId } : {}),
+  };
+}
+
+export function resolveProjectRedirectPath(shareSlug: string | null): string {
+  if (!shareSlug) {
+    throw new Error("Server did not return a shareable link.");
+  }
+  return `/p/${shareSlug}`;
 }
 
 export async function startGenerationViaHttp(
@@ -34,14 +83,123 @@ export async function startGenerationViaHttp(
     body: JSON.stringify(payload),
   });
 
-  const body = (await response.json()) as
+  const body = (await response
+    .json()
+    .catch(() => ({}))) as
     | StartGenerationResponse
     | { detail?: { error?: string; message?: string } };
 
   if (!response.ok) {
-    const detail = (body as { detail?: { error?: string; message?: string } }).detail;
-    throw new Error(detail?.message ?? detail?.error ?? "Failed to start generation");
+    throw new Error(parseErrorMessage(body));
   }
 
   return body as StartGenerationResponse;
+}
+
+async function startDiscoveryViaHttp(
+  answers: Record<string, string | string[] | number>,
+  projectId?: string | null
+): Promise<DiscoveryStartResponse | null> {
+  const payload = await withAccessToken({
+    answers,
+    project_id: projectId ?? undefined,
+  });
+
+  const response = await fetch(`${API_URL}/api/generations/discovery-start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as unknown;
+
+  if (!response.ok) {
+    if (shouldFallbackToDiscoveryWs(response.status)) {
+      return null;
+    }
+    throw new Error(parseErrorMessage(body));
+  }
+
+  const parsed = parseDiscoveryStartResponse(body);
+  if (!parsed) {
+    throw new Error("Discovery start endpoint returned an invalid payload.");
+  }
+  return parsed;
+}
+
+function startDiscoveryViaWebSocket(
+  answers: Record<string, string | string[] | number>,
+  projectId?: string | null
+): Promise<DiscoveryStartResponse> {
+  const timeoutMs = 15_000;
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanupFns: Array<() => void> = [];
+    const timeout = setTimeout(() => {
+      finish(() => reject(new Error("Timed out while creating discovery project.")));
+    }, timeoutMs);
+
+    function finish(action: () => void) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      cleanupFns.forEach((cleanup) => cleanup());
+      action();
+    }
+
+    const unsubscribeMessages = wsClient.onMessage((raw: unknown) => {
+      if (!isRecord(raw)) return;
+      const type = raw.type;
+      if (type === "error") {
+        const message = typeof raw.message === "string" ? raw.message : "Failed to start discovery session.";
+        finish(() => reject(new Error(message)));
+        return;
+      }
+
+      if (type !== "project_ready") return;
+      const projectIdValue = typeof raw.project_id === "string" ? raw.project_id : null;
+      const shareSlug = typeof raw.share_slug === "string" ? raw.share_slug : null;
+      if (!projectIdValue) {
+        finish(() => reject(new Error("Discovery start did not return a project ID.")));
+        return;
+      }
+
+      finish(() =>
+        resolve({
+          project_id: projectIdValue,
+          share_slug: shareSlug,
+          trace_id: typeof raw.trace_id === "string" ? raw.trace_id : "ws-discovery",
+          generation_status: "idle",
+        })
+      );
+    });
+    cleanupFns.push(unsubscribeMessages);
+
+    wsClient.connect();
+    const unsubscribeOpen = wsClient.onOpen(() => {
+      void (async () => {
+        try {
+          const payload = await withAccessToken({
+            type: "chat_discovery_start",
+            ...answers,
+            project_id: projectId ?? undefined,
+          });
+          wsClient.send(payload);
+        } catch (error) {
+          finish(() => reject(error instanceof Error ? error : new Error("Failed to start discovery session.")));
+        }
+      })();
+    });
+    cleanupFns.push(unsubscribeOpen);
+  });
+}
+
+export async function startDiscoverySession(
+  answers: Record<string, string | string[] | number>,
+  projectId?: string | null
+): Promise<DiscoveryStartResponse> {
+  const viaHttp = await startDiscoveryViaHttp(answers, projectId);
+  if (viaHttp) return viaHttp;
+  return startDiscoveryViaWebSocket(answers, projectId);
 }

--- a/frontend/lib/projects.ts
+++ b/frontend/lib/projects.ts
@@ -17,6 +17,7 @@ export type CanvasMessage = {
 };
 
 export type GenerationStatus = "idle" | "queued" | "running" | "completed" | "failed";
+export type ProjectMode = "default" | "discovery";
 export type QuestionnaireAnswers = Record<string, string | string[] | number>;
 
 export type PersistedProject = {
@@ -41,6 +42,7 @@ export type PersistedProject = {
   generationStartedAt: string | null;
   generationCompletedAt: string | null;
   lastEventAt: string | null;
+  projectMode: ProjectMode;
 };
 
 export type ProjectSummary = {
@@ -262,6 +264,19 @@ function parseGenerationStatus(value: unknown): GenerationStatus {
   return "idle";
 }
 
+function parseProjectMode(value: unknown, questionnaireAnswers: QuestionnaireAnswers): ProjectMode {
+  if (value === "discovery" || value === "default") {
+    return value;
+  }
+
+  const legacyMode = questionnaireAnswers._mode;
+  if (legacyMode === "chat_first" || legacyMode === "discovery") {
+    return "discovery";
+  }
+
+  return "default";
+}
+
 export function mapProjectRow(row: unknown): PersistedProject | null {
   if (!isRecord(row)) return null;
   const id = asNonEmptyString(row.id);
@@ -295,6 +310,7 @@ export function mapProjectRow(row: unknown): PersistedProject | null {
     generationStartedAt: asNonEmptyString(row.generation_started_at),
     generationCompletedAt: asNonEmptyString(row.generation_completed_at),
     lastEventAt: asNonEmptyString(row.last_event_at),
+    projectMode: parseProjectMode(row.project_mode, questionnaireAnswers),
   };
 }
 

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDiagramState } from "@/lib/useDiagramState";
 import wsClient, { ConnectionState } from "@/lib/websocket";
 import { startGenerationViaHttp, withAccessToken } from "@/lib/generationStart";
+import {
+  INITIAL_BUDGET_RETRY_STATE,
+  type BudgetRetryState,
+  reduceBudgetRetryState,
+} from "@/lib/budgetRetry";
 import { TerraformFile, CostEstimate } from "@/components/OutputPanel";
 import { ArchDescription } from "@/components/ArchDescriptionViewer";
 import { CanvasMessage, CanvasSession } from "@/lib/projects";
@@ -95,6 +100,24 @@ function latestPendingArchitecturePlanId(messages: CanvasMessage[]): string | nu
   return null;
 }
 
+function isPersistedDiscoverySession(session: CanvasSession | null): boolean {
+  return session?.mode === "existing" && session.project.projectMode === "discovery";
+}
+
+function isDiscoverySession(session: CanvasSession | null): boolean {
+  return session?.mode === "chat_first" || isPersistedDiscoverySession(session);
+}
+
+function toDiscoveryStartAnswers(session: CanvasSession): Record<string, string | string[] | number> {
+  if (session.mode === "chat_first") {
+    return session.answers;
+  }
+  if (session.mode === "existing") {
+    return session.project.questionnaireAnswers;
+  }
+  return session.answers;
+}
+
 export function useCanvasPipeline(
   appState: "dashboard" | "questionnaire" | "canvas",
   canvasSession: CanvasSession | null,
@@ -126,6 +149,7 @@ export function useCanvasPipeline(
   const [traceId, setTraceId] = useState<string | null>(null);
   const [lastEventAt, setLastEventAt] = useState<number | null>(null);
   const [discoveryProjectId, setDiscoveryProjectId] = useState<string | null>(null);
+  const [budgetRetryState, setBudgetRetryState] = useState<BudgetRetryState>(INITIAL_BUDGET_RETRY_STATE);
   const [terraformProgress, setTerraformProgress] = useState<TerraformProgress>({
     status: "idle",
     activity: null,
@@ -207,6 +231,19 @@ export function useCanvasPipeline(
       setTraceId(canvasSession.project.generationTraceId);
       setCurrentStage(canvasSession.project.generationStage);
       setLastEventAt(canvasSession.project.lastEventAt ? Date.parse(canvasSession.project.lastEventAt) : Date.now());
+      if (canvasSession.project.generationStage === "budget_retry") {
+        setBudgetRetryState((prev) =>
+          reduceBudgetRetryState(prev, {
+            stage: "budget_retry",
+            event: null,
+            message: "Budget optimization retry is running.",
+            traceId: canvasSession.project.generationTraceId,
+            timestamp: Date.now(),
+          })
+        );
+      } else if (isFreshSession) {
+        setBudgetRetryState(INITIAL_BUDGET_RETRY_STATE);
+      }
 
       const generationActive =
         canvasSession.project.generationStatus === "queued" ||
@@ -285,6 +322,7 @@ export function useCanvasPipeline(
         setIsGenerating(false);
         setLastEventAt(Date.now());
         stallWarnedRef.current = false;
+        setBudgetRetryState(INITIAL_BUDGET_RETRY_STATE);
         setTerraformProgress({
           status: "idle",
           activity: null,
@@ -324,6 +362,7 @@ export function useCanvasPipeline(
         setDebugEvents([]);
         setCurrentStage("start");
         setTraceId(null);
+        setBudgetRetryState(INITIAL_BUDGET_RETRY_STATE);
         setTerraformProgress({
           status: "planning",
           activity: "Planning Terraform files",
@@ -390,7 +429,6 @@ export function useCanvasPipeline(
       })();
     } else {
       const generationActive =
-        liveSession ||
         canvasSession.project.generationStatus === "queued" ||
         canvasSession.project.generationStatus === "running";
 
@@ -417,6 +455,19 @@ export function useCanvasPipeline(
       setTraceId(canvasSession.project.generationTraceId);
       setCurrentStage(canvasSession.project.generationStage);
       setLastEventAt(canvasSession.project.lastEventAt ? Date.parse(canvasSession.project.lastEventAt) : Date.now());
+      if (canvasSession.project.generationStage === "budget_retry") {
+        setBudgetRetryState((prev) =>
+          reduceBudgetRetryState(prev, {
+            stage: "budget_retry",
+            event: null,
+            message: "Budget optimization retry is running.",
+            traceId: canvasSession.project.generationTraceId,
+            timestamp: Date.now(),
+          })
+        );
+      } else if (isFreshSession) {
+        setBudgetRetryState(INITIAL_BUDGET_RETRY_STATE);
+      }
 
       if (generationActive) {
         setIsGenerating(true);
@@ -480,6 +531,17 @@ export function useCanvasPipeline(
         const status = msg.generation_status;
         const stage = msg.generation_stage;
         if (typeof stage === "string") setCurrentStage(stage);
+        if (stage === "budget_retry") {
+          setBudgetRetryState((prev) =>
+            reduceBudgetRetryState(prev, {
+              stage: "budget_retry",
+              event: null,
+              message: "Budget optimization retry is running.",
+              traceId: incomingTrace ?? traceId,
+              timestamp: Date.now(),
+            })
+          );
+        }
         if (status === "queued" || status === "running") {
           setIsGenerating(true);
           setPipelineStatus(typeof stage === "string" ? `Running: ${stage}` : "Generation running...");
@@ -491,6 +553,17 @@ export function useCanvasPipeline(
           }));
         }
         if (status === "completed") {
+          setBudgetRetryState((prev) =>
+            prev.status === "in_progress"
+              ? reduceBudgetRetryState(prev, {
+                  stage: "budget_cap",
+                  event: "retry_succeeded",
+                  message: "Budget optimization retry completed.",
+                  traceId: incomingTrace ?? traceId,
+                  timestamp: Date.now(),
+                })
+              : prev
+          );
           setIsGenerating(false);
           setPipelineStatus("Architecture ready ✓");
           setTerraformProgress((prev) => ({
@@ -503,6 +576,17 @@ export function useCanvasPipeline(
           }));
         }
         if (status === "failed") {
+          setBudgetRetryState((prev) =>
+            prev.status === "in_progress"
+              ? reduceBudgetRetryState(prev, {
+                  stage: "budget_cap",
+                  event: "retry_failed",
+                  message: String(msg.generation_error ?? "Generation failed"),
+                  traceId: incomingTrace ?? traceId,
+                  timestamp: Date.now(),
+                })
+              : prev
+          );
           setIsGenerating(false);
           setPipelineStatus(`Error: ${String(msg.generation_error ?? "Generation failed")}`);
           setTerraformProgress((prev) => ({
@@ -567,6 +651,16 @@ export function useCanvasPipeline(
           traceId: incomingTrace ?? traceId,
           details,
         });
+        setBudgetRetryState((prev) =>
+          reduceBudgetRetryState(prev, {
+            stage,
+            event: eventName,
+            message,
+            details,
+            traceId: incomingTrace ?? traceId,
+            timestamp: Date.now(),
+          })
+        );
 
         if (stage === "coder") {
           const expectedFromEvent =
@@ -617,6 +711,17 @@ export function useCanvasPipeline(
       }
 
       if (msg.type === "done") {
+        setBudgetRetryState((prev) =>
+          prev.status === "in_progress"
+            ? reduceBudgetRetryState(prev, {
+                stage: "budget_cap",
+                event: "retry_succeeded",
+                message: "Budget optimization retry completed.",
+                traceId: incomingTrace ?? traceId,
+                timestamp: Date.now(),
+              })
+            : prev
+        );
         setIsGenerating(false);
         setPipelineStatus("Architecture ready ✓");
         const startedAt = generationStartRef.current || Date.now();
@@ -654,6 +759,17 @@ export function useCanvasPipeline(
           currentFile: null,
           lastUpdateAt: Date.now(),
         }));
+        setBudgetRetryState((prev) =>
+          prev.status === "in_progress"
+            ? reduceBudgetRetryState(prev, {
+                stage: "budget_cap",
+                event: "retry_failed",
+                message,
+                traceId: incomingTrace ?? traceId,
+                timestamp: Date.now(),
+              })
+            : prev
+        );
         pushDebugEvent({
           ts: Date.now(),
           level: "error",
@@ -934,7 +1050,7 @@ export function useCanvasPipeline(
   const generationCompleted =
     currentStage === "completed" ||
     (canvasSession?.mode === "existing" && canvasSession.project.generationStage === "completed");
-  const isDiscoveryMode = canvasSession?.mode === "chat_first";
+  const isDiscoveryMode = isDiscoverySession(canvasSession);
   const chatEnabled =
     !readOnly &&
     Boolean(activeProjectId) &&
@@ -970,12 +1086,15 @@ export function useCanvasPipeline(
   );
 
   async function triggerGeneration() {
-    if (canvasSession?.mode !== "chat_first") return;
+    if (!canvasSession || !isDiscoverySession(canvasSession)) return;
     const answers: Record<string, string | string[] | number> = {
-      ...canvasSession.answers,
+      ...toDiscoveryStartAnswers(canvasSession),
       _approved_plan: "true",
     };
-    const projectId = canvasSession.projectId ?? discoveryProjectId ?? undefined;
+    const projectId =
+      canvasSession.mode === "existing"
+        ? canvasSession.project.id
+        : canvasSession.projectId ?? discoveryProjectId ?? undefined;
 
     // Build a brief conversation summary from discovery messages
     const discoveryMessages = messagesRef.current;
@@ -989,6 +1108,7 @@ export function useCanvasPipeline(
     setIsGenerating(true);
     setPipelineStatus("Starting generation...");
     setCurrentStage("start");
+    setBudgetRetryState(INITIAL_BUDGET_RETRY_STATE);
     generationStartRef.current = Date.now();
     setLastEventAt(Date.now());
     setTerraformProgress({
@@ -1054,7 +1174,11 @@ export function useCanvasPipeline(
     streamingReplyRef.current = "";
     const projectId = canvasSession?.mode === "existing" ? canvasSession.project.id : canvasSession?.projectId;
     const discoveryModeProjectId =
-      canvasSession?.mode === "chat_first" ? canvasSession.projectId ?? discoveryProjectId : null;
+      canvasSession && isDiscoverySession(canvasSession)
+        ? canvasSession.mode === "existing"
+          ? canvasSession.project.id
+          : canvasSession.projectId ?? discoveryProjectId
+        : null;
     const currentSelectedIds = diagram.selectedNodeIds.length > 0 ? diagram.selectedNodeIds : selectedNodeIds;
     void (async () => {
       const payload = await withAccessToken({
@@ -1068,7 +1192,12 @@ export function useCanvasPipeline(
   }
 
   function handleApprovePlan(planId?: string) {
-    if (!chatEnabled || canvasSession?.mode !== "existing") return;
+    if (!chatEnabled || !canvasSession) return;
+    if (isPersistedDiscoverySession(canvasSession)) {
+      void triggerGeneration();
+      return;
+    }
+    if (canvasSession.mode !== "existing") return;
     const projectId = canvasSession.project.id;
     const targetPlanId = typeof planId === "string" && planId.trim() ? planId.trim() : pendingArchitecturePlanId;
     if (!targetPlanId) return;
@@ -1094,6 +1223,7 @@ export function useCanvasPipeline(
     terraformFiles,
     costEstimate,
     archDescription,
+    budgetRetryState,
     terraformProgress,
     isGenerating,
     agentLogs,

--- a/supabase/migrations/009_project_mode.sql
+++ b/supabase/migrations/009_project_mode.sql
@@ -1,0 +1,37 @@
+alter table if exists projects
+  add column if not exists project_mode text;
+
+update projects
+set project_mode = case
+  when generation_stage = 'discovery' then 'discovery'
+  when generation_stage in (
+    'queued',
+    'running',
+    'requirements',
+    'architect',
+    'parallel_agents',
+    'budget_retry',
+    'completed',
+    'failed'
+  ) then 'default'
+  when coalesce(questionnaire_answers ->> '_mode', '') = 'chat_first' then 'discovery'
+  else 'default'
+end
+where project_mode is null;
+
+update projects
+set project_mode = 'default'
+where project_mode not in ('discovery', 'default');
+
+alter table if exists projects
+  alter column project_mode set default 'default';
+
+alter table if exists projects
+  alter column project_mode set not null;
+
+alter table if exists projects
+  drop constraint if exists projects_project_mode_check;
+
+alter table if exists projects
+  add constraint projects_project_mode_check
+  check (project_mode in ('discovery', 'default'));


### PR DESCRIPTION
## Summary
- route chat-first starts from /new directly to canonical /p/{slug}
- add persisted project_mode (discovery/default) with migration and wire it through backend snapshots + frontend session behavior
- improve budget retry observability with explicit lifecycle state and UI status banner
- add discovery-start HTTP endpoint and regression tests across backend/frontend

## Test Plan
- cd backend && ./.venv/bin/pytest -q
- cd frontend && pnpm exec vitest run
- cd frontend && pnpm exec tsc --noEmit
- cd frontend && pnpm exec next lint
- cd frontend && pnpm build (fails in this workspace due missing Supabase env vars)

Closes #64