### PR TITLE
feat: resilient specialist pipeline retries + incremental completion

### DIFF
--- a/backend/agents/cost_analyst.py
+++ b/backend/agents/cost_analyst.py
@@ -13,6 +13,9 @@ from agents.utils import enrich_requirements
 
 logger = logging.getLogger(__name__)
 
+PRIMARY_HCL_TIMEOUT_SECONDS = 90
+FALLBACK_ESTIMATE_TIMEOUT_SECONDS = 90
+
 COST_HCL_SYSTEM = """
 Generate a minimal Terraform main.tf for cost estimation only.
 Include ONLY resources with direct costs: aws_instance, aws_db_instance,
@@ -62,18 +65,21 @@ async def run_cost_analyst(
 
     enriched = enrich_requirements(requirements, diagram_nodes)
 
-    # Step 1: Generate minimal HCL
-    raw_hcl = await async_complete(
-        messages=[{"role": "user", "content": json.dumps(enriched, indent=2)}],
-        system=COST_HCL_SYSTEM,
-        llm_creds=llm_creds,
-    )
-    raw_hcl = raw_hcl.strip()
-    if raw_hcl.startswith("```"):
-        raw_hcl = raw_hcl.split("\n", 1)[1].rsplit("```", 1)[0]
-
-    # Step 2: Write to temp dir and run infracost
     try:
+        # Step 1: Generate minimal HCL
+        raw_hcl = await asyncio.wait_for(
+            async_complete(
+                messages=[{"role": "user", "content": json.dumps(enriched, indent=2)}],
+                system=COST_HCL_SYSTEM,
+                llm_creds=llm_creds,
+            ),
+            timeout=PRIMARY_HCL_TIMEOUT_SECONDS,
+        )
+        raw_hcl = raw_hcl.strip()
+        if raw_hcl.startswith("```"):
+            raw_hcl = raw_hcl.split("\n", 1)[1].rsplit("```", 1)[0]
+
+        # Step 2: Write to temp dir and run infracost
         await emit_log(websocket, "cost_analyst", "Calling Infracost API", start_time)
         with tempfile.TemporaryDirectory() as tmpdir:
             tf_path = Path(tmpdir) / "main.tf"
@@ -101,6 +107,16 @@ async def run_cost_analyst(
         }))
         await emit_log(websocket, "cost_analyst", "Cost estimate ready", start_time)
 
+    except asyncio.TimeoutError:
+        logger.warning("Cost analyst primary LLM call timed out, using AI estimate fallback", exc_info=True)
+        await websocket.send_text(json.dumps({
+            "type": "pipeline_event",
+            "stage": "cost_analyst",
+            "event": "llm_timeout_fallback",
+            "level": "warning",
+            "message": "Cost analyst timed out while generating HCL; using AI estimate fallback.",
+        }))
+        await _send_estimated_costs(enriched, websocket, start_time, llm_creds=llm_creds)
     except Exception:
         logger.warning("Infracost failed, using AI estimate fallback", exc_info=True)
         await websocket.send_text(json.dumps({
@@ -147,11 +163,35 @@ async def _send_estimated_costs(
 ) -> None:
     await emit_log(websocket, "cost_analyst", "Using AI cost estimation", start_time)
     prompt = "Estimate monthly AWS costs for this architecture:\n" + json.dumps(requirements)
-    raw = await async_complete(
-        messages=[{"role": "user", "content": prompt}],
-        system=COST_ESTIMATE_SYSTEM,
-        llm_creds=llm_creds,
-    )
+    try:
+        raw = await asyncio.wait_for(
+            async_complete(
+                messages=[{"role": "user", "content": prompt}],
+                system=COST_ESTIMATE_SYSTEM,
+                llm_creds=llm_creds,
+            ),
+            timeout=FALLBACK_ESTIMATE_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        await websocket.send_text(json.dumps({
+            "type": "pipeline_event",
+            "stage": "cost_analyst",
+            "event": "fallback_timeout",
+            "level": "warning",
+            "message": "AI fallback cost estimate timed out.",
+        }))
+        await websocket.send_text(json.dumps({
+            "type": "cost_estimate",
+            "data": {
+                "monthly_total": 0,
+                "currency": "USD",
+                "line_items": [],
+                "generated_by": "estimation_failed",
+                "note": "Cost estimation unavailable. Please try again.",
+            }
+        }))
+        return
+
     raw = raw.strip()
     if raw.startswith("```"):
         raw = raw.split("\n", 1)[1].rsplit("```", 1)[0]

--- a/backend/agents/description.py
+++ b/backend/agents/description.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 from typing import Any
 
 from fastapi import WebSocket
@@ -23,6 +24,8 @@ Rules:
 - Keep each paragraph to 2-4 sentences
 - Valid JSON only. No prose before or after the JSON object.
 """
+
+DESCRIPTION_REQUEST_TIMEOUT_SECONDS = 90
 
 
 async def run_description_agent(
@@ -49,11 +52,25 @@ async def run_description_agent(
 
     prompt = "Generate an architecture description for:\n" + json.dumps(enriched, indent=2)
 
-    raw = await async_complete(
-        messages=[{"role": "user", "content": prompt}],
-        system=DESCRIPTION_SYSTEM,
-        llm_creds=llm_creds,
-    )
+    try:
+        raw = await asyncio.wait_for(
+            async_complete(
+                messages=[{"role": "user", "content": prompt}],
+                system=DESCRIPTION_SYSTEM,
+                llm_creds=llm_creds,
+            ),
+            timeout=DESCRIPTION_REQUEST_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        await websocket.send_text(json.dumps({
+            "type": "pipeline_event",
+            "stage": "description",
+            "event": "timeout",
+            "level": "warning",
+            "message": "Description generation timed out.",
+        }))
+        return
+
     raw = raw.strip()
     if raw.startswith("```"):
         raw = raw.split("\n", 1)[1].rsplit("```", 1)[0].strip()

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -5,7 +5,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -262,6 +262,178 @@ def _build_strict_budget_requirements(requirements: dict[str, Any], budget_cap: 
             f"HARD CAP: keep estimated monthly total <= ${budget_cap:.2f}. "
             f"Current estimate is ${estimated_total:.2f}; optimize aggressively to stay within budget."
         ),
+    }
+
+
+_SPECIALIST_HEARTBEAT_SECONDS = 8.0
+_SPECIALIST_RETRY_CONFIG: dict[str, dict[str, float | int]] = {
+    "coder": {
+        "max_retries": 1,
+        "backoff_ms": 200,
+        "attempt_timeout_seconds": 220,
+    },
+    "cost_analyst": {
+        "max_retries": 1,
+        "backoff_ms": 300,
+        "attempt_timeout_seconds": 180,
+    },
+    "description": {
+        "max_retries": 1,
+        "backoff_ms": 250,
+        "attempt_timeout_seconds": 120,
+    },
+}
+
+
+def _specialist_config_for(stage: str) -> dict[str, float | int]:
+    configured = _SPECIALIST_RETRY_CONFIG.get(stage)
+    if isinstance(configured, dict):
+        return configured
+    return {
+        "max_retries": 0,
+        "backoff_ms": 0,
+        "attempt_timeout_seconds": 120,
+    }
+
+
+async def _run_specialists_with_retries(
+    runtime: "GenerationRuntime",
+    factories: dict[str, Callable[[], Awaitable[None]]],
+) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    states: dict[str, dict[str, Any]] = {
+        name: {
+            "state": "queued",
+            "attempts": 0,
+            "retries_used": 0,
+            "max_retries": int(_specialist_config_for(name).get("max_retries", 0) or 0),
+            "last_error": None,
+        }
+        for name in factories
+    }
+
+    async def _run_single(stage: str, factory: Callable[[], Awaitable[None]]) -> None:
+        config = _specialist_config_for(stage)
+        max_retries = int(config.get("max_retries", 0) or 0)
+        backoff_ms = int(config.get("backoff_ms", 0) or 0)
+        attempt_timeout_seconds = float(config.get("attempt_timeout_seconds", 120) or 120)
+        max_attempts = max_retries + 1
+
+        for attempt in range(1, max_attempts + 1):
+            is_retry = attempt > 1
+            current_state = f"retrying({attempt - 1})" if is_retry else "running"
+            states[stage]["state"] = current_state
+            states[stage]["attempts"] = attempt
+            states[stage]["retries_used"] = attempt - 1
+            details = {
+                "state": current_state,
+                "attempt": attempt,
+                "max_retries": max_retries,
+                "attempt_timeout_seconds": attempt_timeout_seconds,
+            }
+
+            if is_retry:
+                await runtime.emit_pipeline_event(
+                    stage,
+                    "retrying",
+                    "warning",
+                    f"{stage} retry {attempt - 1}/{max_retries} started",
+                    details,
+                )
+            else:
+                await runtime.emit_pipeline_event(stage, "started", "info", f"{stage} started", details)
+
+            stage_task = asyncio.create_task(asyncio.wait_for(factory(), timeout=attempt_timeout_seconds))
+            attempt_started_at = loop.time()
+            while not stage_task.done():
+                done, _pending = await asyncio.wait({stage_task}, timeout=_SPECIALIST_HEARTBEAT_SECONDS)
+                if stage_task in done:
+                    break
+                elapsed_ms = int((loop.time() - attempt_started_at) * 1000)
+                await runtime.emit_pipeline_event(
+                    stage,
+                    "still_running",
+                    "info",
+                    f"{stage} still running",
+                    {
+                        "state": current_state,
+                        "attempt": attempt,
+                        "elapsed_ms": elapsed_ms,
+                    },
+                )
+
+            try:
+                await stage_task
+            except Exception as error:
+                error_message = str(error)
+                states[stage]["last_error"] = error_message
+                if attempt < max_attempts:
+                    await runtime.emit_pipeline_event(
+                        stage,
+                        "attempt_failed",
+                        "warning",
+                        f"{stage} attempt {attempt} failed; retrying",
+                        {
+                            "state": current_state,
+                            "attempt": attempt,
+                            "max_retries": max_retries,
+                            "error": error_message,
+                        },
+                    )
+                    computed_backoff_ms = backoff_ms * (2 ** (attempt - 1))
+                    if computed_backoff_ms > 0:
+                        await asyncio.sleep(computed_backoff_ms / 1000)
+                    continue
+
+                states[stage]["state"] = "failed_after_retries"
+                await runtime.emit_pipeline_event(
+                    stage,
+                    "failed_after_retries",
+                    "warning",
+                    f"{stage} failed after retries",
+                    {
+                        "state": "failed_after_retries",
+                        "attempts": attempt,
+                        "max_retries": max_retries,
+                        "error": error_message,
+                    },
+                )
+                return
+
+            states[stage]["state"] = "completed"
+            states[stage]["last_error"] = None
+            await runtime.emit_pipeline_event(
+                stage,
+                "completed",
+                "info",
+                f"{stage} completed",
+                {
+                    "state": "completed",
+                    "attempts": attempt,
+                    "retries_used": attempt - 1,
+                    "elapsed_ms": int((loop.time() - attempt_started_at) * 1000),
+                },
+            )
+            return
+
+    async with asyncio.TaskGroup() as tg:
+        for stage, factory in factories.items():
+            tg.create_task(_run_single(stage, factory))
+
+    completed_count = 0
+    failed_count = 0
+    for specialist_state in states.values():
+        if specialist_state.get("state") == "completed":
+            completed_count += 1
+        else:
+            failed_count += 1
+
+    return {
+        "total": len(states),
+        "completed": completed_count,
+        "failed_after_retries": failed_count,
+        "all_terminal": True,
+        "specialists": states,
     }
 
 
@@ -619,55 +791,33 @@ async def _run_agent_rerun(
             runtime.persistence.terraform_files = []
             await update_project_fields(project_id, user_id, {"terraform_files": [], "last_event_at": _now_utc_iso()})
 
-        async def run_stage(stage: str, coro: Any) -> None:
-            await runtime.emit_pipeline_event(stage, "started", "info", f"{stage} started")
-            try:
-                await coro
-                await runtime.emit_pipeline_event(stage, "completed", "info", f"{stage} completed")
-            except Exception as error:
-                await runtime.emit_pipeline_event(stage, "failed", "error", f"{stage} failed", {"error": str(error)})
-                raise
+        specialist_factories: dict[str, Callable[[], Awaitable[None]]] = {}
+        if "coder" in agent_names:
+            specialist_factories["coder"] = lambda: stream_terraform_files(
+                requirements,
+                runtime,
+                start_time,
+                diagram_nodes=diagram_nodes,
+                llm_creds=llm_creds,
+            )
+        if "cost_analyst" in agent_names:
+            specialist_factories["cost_analyst"] = lambda: run_cost_analyst(
+                requirements,
+                runtime,
+                start_time,
+                diagram_nodes=diagram_nodes,
+                llm_creds=llm_creds,
+            )
+        if "description" in agent_names:
+            specialist_factories["description"] = lambda: run_description_agent(
+                requirements,
+                runtime,
+                start_time,
+                diagram_nodes=diagram_nodes,
+                llm_creds=llm_creds,
+            )
 
-        async with asyncio.TaskGroup() as tg:
-            if "coder" in agent_names:
-                tg.create_task(
-                    run_stage(
-                        "coder",
-                        stream_terraform_files(
-                            requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
-            if "cost_analyst" in agent_names:
-                tg.create_task(
-                    run_stage(
-                        "cost_analyst",
-                        run_cost_analyst(
-                            requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
-            if "description" in agent_names:
-                tg.create_task(
-                    run_stage(
-                        "description",
-                        run_description_agent(
-                            requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
+        specialist_summary = await _run_specialists_with_retries(runtime, specialist_factories)
 
         await runtime.send_text(json.dumps({"type": "done"}))
 
@@ -691,7 +841,13 @@ async def _run_agent_rerun(
         if _thumbnail_url:
             await update_project_fields(project_id, user_id, {"thumbnail_url": _thumbnail_url})
 
-        await runtime.emit_pipeline_event("rerun", "completed", "info", "Selected agents completed")
+        await runtime.emit_pipeline_event(
+            "rerun",
+            "completed",
+            "info",
+            "Selected agents reached terminal states",
+            specialist_summary,
+        )
         await runtime.set_generation_state(status="completed", stage="completed", completed=True)
     except Exception as error:
         await runtime.persist_partial_state()
@@ -829,62 +985,31 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             json.dumps({"type": "status", "message": "Designing architecture and generating Terraform..."})
         )
 
-        async def run_stage(stage: str, coro: Any) -> None:
-            await runtime.emit_pipeline_event(stage, "started", "info", f"{stage} started")
-            try:
-                await coro
-                await runtime.emit_pipeline_event(stage, "completed", "info", f"{stage} completed")
-            except Exception as error:
-                logger.error(
-                    "Stage failed stage=%s project_id=%s trace_id=%s error=%s",
-                    stage, project_id, runtime.trace_id, error,
-                    exc_info=True,
-                )
-                try:
-                    await runtime.emit_pipeline_event(
-                        stage, "failed", "error", f"{stage} failed", {"error": str(error)}
-                    )
-                except Exception:
-                    logger.warning("Could not emit pipeline_event for failed stage=%s", stage)
-
-        async def run_specialist_pass(pass_requirements: dict[str, Any]) -> None:
-            async with asyncio.TaskGroup() as tg:
-                tg.create_task(
-                    run_stage(
-                        "coder",
-                        stream_terraform_files(
-                            pass_requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
-                tg.create_task(
-                    run_stage(
-                        "cost_analyst",
-                        run_cost_analyst(
-                            pass_requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
-                tg.create_task(
-                    run_stage(
-                        "description",
-                        run_description_agent(
-                            pass_requirements,
-                            runtime,
-                            start_time,
-                            diagram_nodes=diagram_nodes,
-                            llm_creds=llm_creds,
-                        ),
-                    )
-                )
+        async def run_specialist_pass(pass_requirements: dict[str, Any]) -> dict[str, Any]:
+            specialist_factories: dict[str, Callable[[], Awaitable[None]]] = {
+                "coder": lambda: stream_terraform_files(
+                    pass_requirements,
+                    runtime,
+                    start_time,
+                    diagram_nodes=diagram_nodes,
+                    llm_creds=llm_creds,
+                ),
+                "cost_analyst": lambda: run_cost_analyst(
+                    pass_requirements,
+                    runtime,
+                    start_time,
+                    diagram_nodes=diagram_nodes,
+                    llm_creds=llm_creds,
+                ),
+                "description": lambda: run_description_agent(
+                    pass_requirements,
+                    runtime,
+                    start_time,
+                    diagram_nodes=diagram_nodes,
+                    llm_creds=llm_creds,
+                ),
+            }
+            return await _run_specialists_with_retries(runtime, specialist_factories)
 
         # Run architect first so downstream agents have access to the diagram nodes
         await runtime.emit_pipeline_event("architect", "started", "info", "architect started")
@@ -903,9 +1028,14 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
         # Run remaining agents in parallel with architect context
         await runtime.emit_pipeline_event("pipeline", "parallel_agents_started", "info", "Running specialist agents")
         await runtime.set_generation_state(status="running", stage="parallel_agents")
-        await run_specialist_pass(requirements)
+        specialist_summary = await run_specialist_pass(requirements)
 
-        logger.info("Parallel agents complete project_id=%s trace_id=%s", project_id, runtime.trace_id)
+        logger.info(
+            "Parallel agents reached terminal states project_id=%s trace_id=%s summary=%s",
+            project_id,
+            runtime.trace_id,
+            specialist_summary,
+        )
 
         initial_budget_cap = _runtime_budget_cap(runtime)
         initial_estimated_total = _runtime_estimated_total(runtime)
@@ -937,7 +1067,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             )
 
             runtime.persistence.terraform_files = []
-            await run_specialist_pass(strict_requirements)
+            specialist_summary = await run_specialist_pass(strict_requirements)
 
             final_budget_cap = _runtime_budget_cap(runtime) or initial_budget_cap
             final_estimated_total = _runtime_estimated_total(runtime)
@@ -990,7 +1120,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
         if _thumbnail_url:
             await update_project_fields(project_id, user_id, {"thumbnail_url": _thumbnail_url})
 
-        await runtime.emit_pipeline_event("pipeline", "completed", "info", "Generation completed")
+        await runtime.emit_pipeline_event("pipeline", "completed", "info", "Generation completed", specialist_summary)
         await runtime.set_generation_state(status="completed", stage="completed", completed=True)
         logger.info("Generation completed project_id=%s trace_id=%s", project_id, runtime.trace_id)
 

--- a/backend/tests/agents/test_cost_analyst.py
+++ b/backend/tests/agents/test_cost_analyst.py
@@ -150,3 +150,46 @@ def test_parse_infracost_output():
     assert result["generated_by"] == "infracost"
     assert len(result["line_items"]) == 2  # zero-cost filtered
     assert result["line_items"][0]["monthly_cost"] >= result["line_items"][1]["monthly_cost"]
+
+
+def test_primary_llm_timeout_falls_back_to_ai_estimate():
+    async def run():
+        ws = MockWebSocket()
+        with patch("agents.cost_analyst.async_complete", new=AsyncMock(side_effect=[
+            asyncio.TimeoutError(),
+            SAMPLE_CLAUDE_ESTIMATE,
+        ])):
+            from agents.cost_analyst import run_cost_analyst
+            await run_cost_analyst({"app_type": "web"}, ws)
+        return ws.sent
+
+    sent = asyncio.run(run())
+    estimate = next(m for m in sent if m["type"] == "cost_estimate")
+    assert estimate["data"]["generated_by"] == "claude_estimate"
+    timeout_event = next(
+        m for m in sent
+        if m.get("type") == "pipeline_event" and m.get("stage") == "cost_analyst" and m.get("event") == "llm_timeout_fallback"
+    )
+    assert timeout_event["level"] == "warning"
+
+
+def test_fallback_llm_timeout_emits_estimation_failed_placeholder():
+    async def run():
+        ws = MockWebSocket()
+        with patch("agents.cost_analyst.async_complete", new=AsyncMock(side_effect=[
+            SAMPLE_HCL,
+            asyncio.TimeoutError(),
+        ])):
+            with patch("subprocess.run", side_effect=FileNotFoundError("infracost not found")):
+                from agents.cost_analyst import run_cost_analyst
+                await run_cost_analyst({"app_type": "web"}, ws)
+        return ws.sent
+
+    sent = asyncio.run(run())
+    estimate = next(m for m in sent if m["type"] == "cost_estimate")
+    assert estimate["data"]["generated_by"] == "estimation_failed"
+    timeout_event = next(
+        m for m in sent
+        if m.get("type") == "pipeline_event" and m.get("stage") == "cost_analyst" and m.get("event") == "fallback_timeout"
+    )
+    assert timeout_event["level"] == "warning"

--- a/backend/tests/agents/test_description.py
+++ b/backend/tests/agents/test_description.py
@@ -1,0 +1,27 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+
+class MockWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_text(self, text):
+        self.sent.append(json.loads(text))
+
+
+def test_description_timeout_emits_pipeline_event():
+    async def run():
+        ws = MockWebSocket()
+        with patch("agents.description.async_complete", new=AsyncMock(side_effect=asyncio.TimeoutError())):
+            from agents.description import run_description_agent
+            await run_description_agent({"app_type": "web"}, ws)
+        return ws.sent
+
+    sent = asyncio.run(run())
+    event = next(
+        m for m in sent
+        if m.get("type") == "pipeline_event" and m.get("stage") == "description" and m.get("event") == "timeout"
+    )
+    assert event["level"] == "warning"

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -287,3 +287,136 @@ async def test_budget_over_cap_after_retry_emits_budget_cap_unmet_and_no_done():
     assert error_payload["error"] == "budget_cap_unmet"
     assert "120.0" in error_payload["message"]
     assert "160.0" in error_payload["message"]
+
+
+def _pipeline_event_exists(runtime: _FakeRuntime, stage: str, event: str) -> bool:
+    for args, _kwargs in runtime.pipeline_events:
+        if len(args) < 2:
+            continue
+        if args[0] == stage and args[1] == event:
+            return True
+    return False
+
+
+def _pipeline_event_details(runtime: _FakeRuntime, stage: str, event: str) -> dict | None:
+    for args, _kwargs in runtime.pipeline_events:
+        if len(args) < 2:
+            continue
+        if args[0] == stage and args[1] == event:
+            if len(args) >= 5 and isinstance(args[4], dict):
+                return args[4]
+            return None
+    return None
+
+
+@pytest.mark.asyncio
+async def test_specialist_failure_does_not_fail_pipeline_and_reports_partial_summary():
+    specialist_calls = {"coder": 0, "cost_analyst": 0, "description": 0}
+
+    async def _architect(_requirements, runtime, _start_time, **_kwargs):
+        runtime.persistence.nodes.append({"id": "node-1"})
+
+    async def _coder(*_args, **_kwargs):
+        specialist_calls["coder"] += 1
+
+    async def _cost_analyst(*_args, **_kwargs):
+        specialist_calls["cost_analyst"] += 1
+        raise RuntimeError("cost analyst failed")
+
+    async def _description(*_args, **_kwargs):
+        specialist_calls["description"] += 1
+
+    runtime = _FakeRuntime()
+
+    with patch("generation_service.generate_requirements", new=AsyncMock(return_value={"app_name": "Demo"})):
+        with patch("generation_service.stream_architecture", new=_architect):
+            with patch("generation_service.stream_terraform_files", new=_coder):
+                with patch("generation_service.run_cost_analyst", new=_cost_analyst):
+                    with patch("generation_service.run_description_agent", new=_description):
+                        with patch("generation_service.emit_log", new=AsyncMock(return_value=None)):
+                            await generation_service._run_generation(runtime, {"app_name": "Demo"})
+
+    assert specialist_calls["coder"] == 1
+    assert specialist_calls["description"] == 1
+    assert specialist_calls["cost_analyst"] >= 1
+    assert any(payload.get("type") == "done" for payload in runtime.sent_payloads)
+    assert not any(payload.get("type") == "error" for payload in runtime.sent_payloads)
+    assert _pipeline_event_exists(runtime, "cost_analyst", "failed_after_retries")
+    summary = _pipeline_event_details(runtime, "pipeline", "completed")
+    assert isinstance(summary, dict)
+    assert summary["specialists"]["coder"]["state"] == "completed"
+    assert summary["specialists"]["description"]["state"] == "completed"
+    assert summary["specialists"]["cost_analyst"]["state"] == "failed_after_retries"
+
+
+@pytest.mark.asyncio
+async def test_specialist_retries_are_independent():
+    specialist_calls = {"coder": 0, "cost_analyst": 0, "description": 0}
+
+    async def _architect(_requirements, runtime, _start_time, **_kwargs):
+        runtime.persistence.nodes.append({"id": "node-1"})
+
+    async def _coder(*_args, **_kwargs):
+        specialist_calls["coder"] += 1
+
+    async def _cost_analyst(*_args, **_kwargs):
+        specialist_calls["cost_analyst"] += 1
+        if specialist_calls["cost_analyst"] == 1:
+            raise RuntimeError("temporary error")
+
+    async def _description(*_args, **_kwargs):
+        specialist_calls["description"] += 1
+
+    runtime = _FakeRuntime()
+
+    with patch("generation_service.generate_requirements", new=AsyncMock(return_value={"app_name": "Demo"})):
+        with patch("generation_service.stream_architecture", new=_architect):
+            with patch("generation_service.stream_terraform_files", new=_coder):
+                with patch("generation_service.run_cost_analyst", new=_cost_analyst):
+                    with patch("generation_service.run_description_agent", new=_description):
+                        with patch("generation_service.emit_log", new=AsyncMock(return_value=None)):
+                            await generation_service._run_generation(runtime, {"app_name": "Demo"})
+
+    assert specialist_calls == {"coder": 1, "cost_analyst": 2, "description": 1}
+    assert any(payload.get("type") == "done" for payload in runtime.sent_payloads)
+    assert not any(payload.get("type") == "error" for payload in runtime.sent_payloads)
+    assert _pipeline_event_exists(runtime, "cost_analyst", "retrying")
+    assert _pipeline_event_exists(runtime, "cost_analyst", "completed")
+
+
+@pytest.mark.asyncio
+async def test_rerun_specialist_failure_does_not_fail_whole_rerun():
+    specialist_calls = {"coder": 0, "cost_analyst": 0, "description": 0}
+
+    async def _coder(*_args, **_kwargs):
+        specialist_calls["coder"] += 1
+
+    async def _cost_analyst(*_args, **_kwargs):
+        specialist_calls["cost_analyst"] += 1
+        raise RuntimeError("cost analyst failed")
+
+    async def _description(*_args, **_kwargs):
+        specialist_calls["description"] += 1
+
+    runtime = _FakeRuntime()
+
+    with patch("generation_service.generate_requirements", new=AsyncMock(return_value={"app_name": "Demo"})):
+        with patch("generation_service.stream_terraform_files", new=_coder):
+            with patch("generation_service.run_cost_analyst", new=_cost_analyst):
+                with patch("generation_service.run_description_agent", new=_description):
+                    with patch("generation_service.update_project_fields", new=AsyncMock(return_value=None)):
+                        await generation_service._run_agent_rerun(
+                            runtime=runtime,
+                            answers={"app_name": "Demo"},
+                            agent_names=("coder", "cost_analyst", "description"),
+                            diagram_nodes=[{"id": "node-1"}],
+                        )
+
+    assert specialist_calls["coder"] == 1
+    assert specialist_calls["description"] == 1
+    assert specialist_calls["cost_analyst"] >= 1
+    assert any(payload.get("type") == "done" for payload in runtime.sent_payloads)
+    assert not any(payload.get("type") == "error" for payload in runtime.sent_payloads)
+    summary = _pipeline_event_details(runtime, "rerun", "completed")
+    assert isinstance(summary, dict)
+    assert summary["specialists"]["cost_analyst"]["state"] == "failed_after_retries"

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -381,7 +381,65 @@ type AgentLogEntry = {
 
 ---
 
-## 11. Diagram Event Schema v2
+## 11. Pipeline Event Schema
+
+The backend emits `pipeline_event` messages during generation/rerun orchestration.
+
+```json
+{
+  "type": "pipeline_event",
+  "stage": "cost_analyst",
+  "event": "retrying",
+  "level": "warning",
+  "message": "cost_analyst retry 1/1 started",
+  "details": {
+    "state": "retrying(1)",
+    "attempt": 2,
+    "max_retries": 1
+  },
+  "trace_id": "uuid",
+  "project_id": "uuid"
+}
+```
+
+**Fields:**
+- `stage`: pipeline stage, including `requirements`, `architect`, `coder`, `cost_analyst`, `description`, `pipeline`, `rerun`, `budget_cap`
+- `event`: stage lifecycle event (examples below)
+- `level`: `"info"` | `"warning"` | `"error"`
+- `message`: human-readable progress text
+- `details`: optional event-specific payload
+
+**Specialist lifecycle events (`coder`, `cost_analyst`, `description`):**
+- `started`
+- `still_running` (heartbeat with elapsed time)
+- `retrying`
+- `attempt_failed`
+- `completed`
+- `failed_after_retries`
+
+**Pipeline/Rerun terminal event details (`stage="pipeline"| "rerun"`, `event="completed"`):**
+```json
+{
+  "total": 3,
+  "completed": 2,
+  "failed_after_retries": 1,
+  "all_terminal": true,
+  "specialists": {
+    "coder": { "state": "completed", "attempts": 1, "retries_used": 0, "max_retries": 1, "last_error": null },
+    "cost_analyst": { "state": "failed_after_retries", "attempts": 2, "retries_used": 1, "max_retries": 1, "last_error": "..." },
+    "description": { "state": "completed", "attempts": 1, "retries_used": 0, "max_retries": 1, "last_error": null }
+  }
+}
+```
+
+**Terminal semantics:**
+- `pipeline`/`rerun` emit `completed` when all selected specialists reach a terminal state (`completed` or `failed_after_retries`)
+- A specialist terminal failure does not automatically fail the whole pipeline
+- Full pipeline `failed` is reserved for pre-specialist critical failures (for example, architect failure) and other unrecoverable errors
+
+---
+
+## 12. Diagram Event Schema v2
 
 Extended `add_node` event:
 ```json

--- a/documents/plans/2026-03-18-issue-66-pipeline-resilience.md
+++ b/documents/plans/2026-03-18-issue-66-pipeline-resilience.md
@@ -1,0 +1,107 @@
+# Issue #66 Pipeline Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make specialist execution resilient so one specialist failure does not fail the full pipeline, with independent retries, attempt timeouts, and incremental completion semantics.
+
+**Architecture:** Keep stage order `requirements -> architect -> specialists_parallel`. Replace the current fail-fast TaskGroup specialist execution with a shared orchestration helper that runs each specialist in its own retry loop with hard attempt timeout, emits per-specialist lifecycle events, and returns a terminal summary used by both full generation and rerun paths.
+
+**Tech Stack:** Python 3.12, asyncio, FastAPI runtime layer, pytest.
+
+---
+
+## File Structure
+
+- Modify: `backend/generation_service.py`
+  - Add shared specialist orchestration utilities, retry state tracking, heartbeat emission, and terminal summary semantics.
+  - Apply shared helper in both `_run_generation` and `_run_agent_rerun`.
+- Modify: `backend/agents/cost_analyst.py`
+  - Add hard timeout wrappers for primary and fallback LLM calls.
+- Modify: `backend/agents/description.py`
+  - Add hard timeout wrapper for LLM call.
+- Modify: `backend/tests/test_generation_service.py`
+  - Add tests for independent retries, partial success, and terminal pipeline semantics.
+- Modify: `backend/tests/agents/test_cost_analyst.py`
+  - Add timeout behavior tests.
+- Modify: `backend/tests/agents/test_description.py` (create)
+  - Add timeout behavior tests for description agent.
+- Modify: `documents/data-reference.md`
+  - Document new pipeline event semantics and terminal summary payload.
+
+## Tasks
+
+### Task 1: Shared specialist orchestration helper (test-first)
+
+**Files:**
+- Modify: `backend/tests/test_generation_service.py`
+- Modify: `backend/generation_service.py`
+
+- [ ] **Step 1: Write failing tests**
+  - Specialist failure does not fail full generation when siblings can complete.
+  - Per-specialist retry attempts are independent.
+  - Pipeline emits terminal `completed` with specialist summary showing success/failure counts.
+
+- [ ] **Step 2: Run targeted tests and confirm failure**
+  - Run: `cd backend && uv run pytest tests/test_generation_service.py -k "specialist or pipeline" -q`
+
+- [ ] **Step 3: Implement shared helper in generation_service**
+  - Introduce specialist config/state model with `queued -> running -> retrying(n) -> completed|failed_after_retries`.
+  - Add bounded per-attempt timeout and retry/backoff.
+  - Emit incremental completion events and heartbeat `still_running` while attempts are active.
+  - Return terminal summary for caller.
+
+- [ ] **Step 4: Re-run targeted tests and make green**
+  - Run: `cd backend && uv run pytest tests/test_generation_service.py -q`
+
+### Task 2: Apply helper to rerun path (test-first)
+
+**Files:**
+- Modify: `backend/tests/test_generation_service.py`
+- Modify: `backend/generation_service.py`
+
+- [ ] **Step 1: Write failing rerun test**
+  - Rerun should complete with partial success if one selected specialist fails after retries.
+
+- [ ] **Step 2: Run rerun-focused tests and confirm failure**
+  - Run: `cd backend && uv run pytest tests/test_generation_service.py -k rerun -q`
+
+- [ ] **Step 3: Integrate shared helper into `_run_agent_rerun`**
+  - Replace TaskGroup fail-fast rerun with shared orchestration and terminal summary behavior.
+
+- [ ] **Step 4: Re-run rerun tests and make green**
+  - Run: `cd backend && uv run pytest tests/test_generation_service.py -k rerun -q`
+
+### Task 3: Agent hard timeouts (test-first)
+
+**Files:**
+- Modify: `backend/tests/agents/test_cost_analyst.py`
+- Create: `backend/tests/agents/test_description.py`
+- Modify: `backend/agents/cost_analyst.py`
+- Modify: `backend/agents/description.py`
+
+- [ ] **Step 1: Add failing timeout tests**
+  - Cost analyst primary/fallback LLM calls time out and surface pipeline warning/error event paths.
+  - Description LLM call timeout emits parse/timeout failure event without crashing.
+
+- [ ] **Step 2: Run targeted tests and confirm failure**
+  - Run: `cd backend && uv run pytest tests/agents/test_cost_analyst.py tests/agents/test_description.py -q`
+
+- [ ] **Step 3: Implement timeouts**
+  - Wrap `async_complete` calls with `asyncio.wait_for` using shared constants.
+  - Emit explicit timeout pipeline events for observability.
+
+- [ ] **Step 4: Re-run targeted tests and make green**
+  - Run: `cd backend && uv run pytest tests/agents/test_cost_analyst.py tests/agents/test_description.py -q`
+
+### Task 4: Contracts + verification
+
+**Files:**
+- Modify: `documents/data-reference.md`
+- Modify: `backend/tests/test_generation_service.py`
+
+- [ ] **Step 1: Update docs for new pipeline event details and terminal summary payload**
+- [ ] **Step 2: Add or update assertions for event payload shape**
+- [ ] **Step 3: Run full relevant backend test suites**
+  - Run: `cd backend && uv run pytest tests/test_generation_service.py tests/agents/test_cost_analyst.py tests/agents/test_description.py -q`
+- [ ] **Step 4: Optional broader confidence run**
+  - Run: `cd backend && uv run pytest -q`


### PR DESCRIPTION
## Summary
- replace fail-fast specialist orchestration with per-specialist retry/timeout state machines and heartbeat events
- keep generation/rerun alive on individual specialist terminal failures and emit terminal completion summaries
- add hard LLM timeouts for cost analyst and description agents, plus regression tests and contract docs updates

## Test Plan
- [x] cd backend && uv run pytest tests/test_generation_service.py tests/agents/test_cost_analyst.py tests/agents/test_description.py -q
- [x] cd backend && uv run pytest -q

Closes #66