### PR TITLE
feat: start from template modal + clone flow (#70)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,17 @@ from pydantic import BaseModel
 from admin import is_admin_email
 from auth import verify_access_token_user
 from generation_service import GenerationStartError, append_chat_history, start_generation_for_user
-from project_store import create_project_for_generation, get_project_for_user, reset_stale_generations, update_project_fields
+from llm_keys import get_user_llm_key_status
+from project_store import (
+    TemplateNotFoundError,
+    clone_template_project_for_user,
+    create_project_for_generation,
+    get_project_for_user,
+    list_template_projects,
+    reset_stale_generations,
+    update_project_fields,
+)
+from quota import check_and_reserve_quota
 from supabase_client import supabase
 from ws_handler import handle_websocket
 
@@ -149,6 +159,21 @@ class LlmKeyStatusResponse(BaseModel):
     has_key: bool
     provider: str | None = None
     model: str | None = None
+
+
+class TemplateSummaryResponse(BaseModel):
+    title: str
+    share_slug: str
+    thumbnail_url: str | None = None
+
+
+class CloneTemplateRequest(BaseModel):
+    access_token: str | None = None
+    auth_token: str | None = None
+
+
+class CloneTemplateResponse(BaseModel):
+    share_slug: str
 
 
 def _normalize_regions(data: dict[str, Any]) -> list[str]:
@@ -366,6 +391,87 @@ async def me_entitlements_endpoint(authorization: str | None = Header(default=No
         raise HTTPException(status_code=401, detail={"error": "invalid_token", "message": "Invalid access token."})
 
     return {"is_admin": is_admin_email(auth_user.email)}
+
+
+@app.get(
+    "/api/templates",
+    summary="List architecture templates",
+    description="Returns all template project metadata for dashboard template selection.",
+    response_model=list[TemplateSummaryResponse],
+    tags=["templates"],
+)
+async def list_templates_endpoint():
+    try:
+        return await list_template_projects()
+    except Exception as error:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "templates_fetch_failed", "message": "Unable to load templates right now."},
+        ) from error
+
+
+@app.post(
+    "/api/templates/{slug}/clone",
+    summary="Clone a template project",
+    description="Clones a template into a new user-owned completed project and returns its new share slug.",
+    response_model=CloneTemplateResponse,
+    tags=["templates"],
+)
+async def clone_template_endpoint(slug: str, req: CloneTemplateRequest):
+    token = req.access_token or req.auth_token
+    if not isinstance(token, str) or not token.strip():
+        raise HTTPException(status_code=401, detail={"error": "unauthenticated", "message": "Missing access token."})
+
+    auth_user = await verify_access_token_user(token)
+    if auth_user is None:
+        raise HTTPException(status_code=401, detail={"error": "invalid_token", "message": "Invalid access token."})
+
+    has_byok = False
+    try:
+        key_status = await get_user_llm_key_status(auth_user.user_id)
+        has_byok = isinstance(key_status, dict) and key_status.get("has_key") is True
+    except Exception:
+        has_byok = False
+
+    if not is_admin_email(auth_user.email) and not has_byok:
+        try:
+            reservation = await check_and_reserve_quota(auth_user.user_id)
+        except Exception as error:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "quota_check_failed", "message": "Unable to check generation quota. Please try again."},
+            ) from error
+
+        if not reservation.get("ok"):
+            err = reservation.get("error", "quota_exhausted")
+            if err == "profile_not_found":
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": "quota_check_failed", "message": "Unable to check generation quota. Please try again."},
+                )
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "quota_exhausted", "message": "You've used all available free generations."},
+            )
+
+    try:
+        cloned = await clone_template_project_for_user(slug, auth_user.user_id)
+    except TemplateNotFoundError as error:
+        raise HTTPException(status_code=404, detail={"error": "template_not_found", "message": str(error)}) from error
+    except Exception as error:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "template_clone_failed", "message": "Unable to clone template."},
+        ) from error
+
+    share_slug = cloned.get("share_slug")
+    if not isinstance(share_slug, str) or not share_slug.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "template_clone_failed", "message": "Unable to clone template."},
+        )
+
+    return {"share_slug": share_slug}
 
 
 @app.post(

--- a/backend/project_store.py
+++ b/backend/project_store.py
@@ -14,6 +14,10 @@ SLUG_LENGTH = 8
 MAX_SLUG_ATTEMPTS = 15
 
 
+class TemplateNotFoundError(RuntimeError):
+    """Raised when the requested template slug does not exist."""
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -236,3 +240,124 @@ def _append_chat_message_sync(project_id: str, user_id: str, message: dict[str, 
 async def append_chat_message(project_id: str, user_id: str, message: dict[str, Any]) -> None:
     """Atomically append a single chat message to a project's chat_history column."""
     await asyncio.to_thread(_append_chat_message_sync, project_id, user_id, message)
+
+
+def _list_template_projects_sync() -> list[dict[str, Any]]:
+    response = (
+        supabase.table("projects")
+        .select("title, share_slug, thumbnail_url")
+        .eq("is_template", True)
+        .order("updated_at", desc=True)
+        .execute()
+    )
+    data = getattr(response, "data", None)
+    if not isinstance(data, list):
+        return []
+
+    templates: list[dict[str, Any]] = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+
+        slug = row.get("share_slug")
+        title = row.get("title")
+        if not isinstance(slug, str) or not slug.strip() or not isinstance(title, str) or not title.strip():
+            continue
+
+        thumbnail_url = row.get("thumbnail_url") if isinstance(row.get("thumbnail_url"), str) else None
+        templates.append(
+            {
+                "title": title.strip(),
+                "share_slug": slug.strip(),
+                "thumbnail_url": thumbnail_url,
+            }
+        )
+
+    return templates
+
+
+async def list_template_projects() -> list[dict[str, Any]]:
+    return await asyncio.to_thread(_list_template_projects_sync)
+
+
+def _clone_template_project_for_user_sync(template_slug: str, user_id: str) -> dict[str, Any]:
+    template = (
+        supabase.table("projects")
+        .select(
+            "title, questionnaire_answers, nodes, edges, terraform_files, "
+            "cost_estimate, description, thumbnail_url"
+        )
+        .eq("is_template", True)
+        .eq("share_slug", template_slug)
+        .single()
+        .execute()
+    )
+    template_data = getattr(template, "data", None)
+    if not isinstance(template_data, dict):
+        raise TemplateNotFoundError("Template not found.")
+
+    payload = {
+        "user_id": user_id,
+        "title": template_data.get("title") if isinstance(template_data.get("title"), str) else "Untitled Project",
+        "project_mode": "default",
+        "questionnaire_answers": template_data.get("questionnaire_answers")
+        if isinstance(template_data.get("questionnaire_answers"), dict)
+        else {},
+        "nodes": template_data.get("nodes") if isinstance(template_data.get("nodes"), list) else [],
+        "edges": template_data.get("edges") if isinstance(template_data.get("edges"), list) else [],
+        "terraform_files": template_data.get("terraform_files") if isinstance(template_data.get("terraform_files"), list) else [],
+        "cost_estimate": template_data.get("cost_estimate"),
+        "description": template_data.get("description"),
+        "chat_history": [],
+        "generation_status": "completed",
+        "generation_stage": "completed",
+        "generation_error": None,
+        "generation_trace_id": None,
+        "generation_started_at": None,
+        "generation_completed_at": _utc_now(),
+        "last_event_at": _utc_now(),
+        "thumbnail_url": template_data.get("thumbnail_url") if isinstance(template_data.get("thumbnail_url"), str) else None,
+        "is_template": False,
+        "updated_at": _utc_now(),
+    }
+
+    last_error: Exception | None = None
+    for _ in range(MAX_SLUG_ATTEMPTS):
+        slug = _generate_slug()
+        try:
+            result = (
+                supabase.table("projects")
+                .insert({**payload, "share_slug": slug})
+                .execute()
+            )
+        except Exception as error:
+            if _is_duplicate_slug_error(error):
+                last_error = error
+                continue
+            raise
+
+        data = getattr(result, "data", None)
+        if isinstance(data, list) and data:
+            row = data[0]
+            if isinstance(row, dict):
+                return row
+
+        fetched = (
+            supabase.table("projects")
+            .select("id, share_slug")
+            .eq("user_id", user_id)
+            .eq("share_slug", slug)
+            .single()
+            .execute()
+        )
+        fetched_data = getattr(fetched, "data", None)
+        if isinstance(fetched_data, dict):
+            return fetched_data
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Unable to clone template with a unique slug.")
+
+
+async def clone_template_project_for_user(template_slug: str, user_id: str) -> dict[str, Any]:
+    return await asyncio.to_thread(_clone_template_project_for_user_sync, template_slug, user_id)

--- a/backend/tests/test_templates_endpoint.py
+++ b/backend/tests/test_templates_endpoint.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+def test_get_templates_returns_public_template_metadata(client):
+    templates = [
+        {"title": "ECS + RDS", "share_slug": "tmpl0001", "thumbnail_url": "https://cdn.example/t1.png"},
+        {"title": "Lambda + API Gateway", "share_slug": "tmpl0002", "thumbnail_url": None},
+    ]
+
+    with patch("main.list_template_projects", new=AsyncMock(return_value=templates), create=True):
+        response = client.get("/api/templates")
+
+    assert response.status_code == 200
+    assert response.json() == templates
+
+
+def test_clone_template_requires_token(client):
+    response = client.post("/api/templates/tmpl0001/clone", json={})
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "unauthenticated"
+
+
+def test_clone_template_rejects_invalid_token(client):
+    with patch("main.verify_access_token_user", return_value=None):
+        response = client.post(
+            "/api/templates/tmpl0001/clone",
+            json={"access_token": "bad-token"},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "invalid_token"
+
+
+def test_clone_template_reserves_quota_when_no_admin_and_no_byok(client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+
+    with patch("main.verify_access_token_user", return_value=auth_user):
+        with patch("main.is_admin_email", return_value=False, create=True):
+            with patch("main.get_user_llm_key_status", new=AsyncMock(return_value=None), create=True):
+                with patch(
+                    "main.check_and_reserve_quota",
+                    new=AsyncMock(return_value={"ok": True, "error": None, "generations_used": 1, "generations_limit": 5}),
+                    create=True,
+                ) as mock_quota:
+                    with patch(
+                        "main.clone_template_project_for_user",
+                        new=AsyncMock(return_value={"id": "project-1", "share_slug": "clone1234"}),
+                        create=True,
+                    ) as mock_clone:
+                        response = client.post(
+                            "/api/templates/tmpl0001/clone",
+                            json={"access_token": "good-token"},
+                        )
+
+    assert response.status_code == 200
+    assert response.json() == {"share_slug": "clone1234"}
+    mock_quota.assert_awaited_once_with("user-123")
+    mock_clone.assert_awaited_once_with("tmpl0001", "user-123")
+
+
+def test_clone_template_bypasses_quota_for_byok_user(client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+
+    with patch("main.verify_access_token_user", return_value=auth_user):
+        with patch("main.is_admin_email", return_value=False, create=True):
+            with patch("main.get_user_llm_key_status", new=AsyncMock(return_value={"has_key": True}), create=True):
+                with patch("main.check_and_reserve_quota", new=AsyncMock(), create=True) as mock_quota:
+                    with patch(
+                        "main.clone_template_project_for_user",
+                        new=AsyncMock(return_value={"id": "project-1", "share_slug": "clone1234"}),
+                        create=True,
+                    ):
+                        response = client.post(
+                            "/api/templates/tmpl0001/clone",
+                            json={"access_token": "good-token"},
+                        )
+
+    assert response.status_code == 200
+    assert response.json() == {"share_slug": "clone1234"}
+    mock_quota.assert_not_awaited()
+
+
+def test_clone_template_returns_quota_exhausted_error(client):
+    auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")
+
+    with patch("main.verify_access_token_user", return_value=auth_user):
+        with patch("main.is_admin_email", return_value=False, create=True):
+            with patch("main.get_user_llm_key_status", new=AsyncMock(return_value=None), create=True):
+                with patch(
+                    "main.check_and_reserve_quota",
+                    new=AsyncMock(return_value={"ok": False, "error": "quota_exhausted", "generations_used": 5, "generations_limit": 5}),
+                    create=True,
+                ):
+                    response = client.post(
+                        "/api/templates/tmpl0001/clone",
+                        json={"access_token": "good-token"},
+                    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"] == "quota_exhausted"

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -192,6 +192,7 @@ The projects table persists all diagram state and generation metadata in Supabas
 | `description` | JSONB | YES | Architecture description with sections (overview, key_components, tradeoffs, next_steps) |
 | `chat_history` | JSONB | YES | Array of chat messages (role, content) |
 | `share_slug` | TEXT | YES | Unique 8-character slug for anonymous shareable links |
+| `is_template` | BOOLEAN | NO | Marks a project as a reusable template source (`true`) or regular user project (`false`) |
 | `generation_status` | TEXT | YES | Current generation state: idle, queued, running, complete, failed |
 | `generation_stage` | TEXT | YES | Current pipeline stage: requirements, architect, parallel_agents, done |
 | `generation_error` | TEXT | YES | Error message if generation_status is failed |
@@ -207,6 +208,8 @@ The projects table persists all diagram state and generation metadata in Supabas
 - `share_slug` is unique across all projects (enforced at DB level)
 - `user_id` enforces row-level security; users can only access their own projects
 - `project_mode` is constrained to `default` or `discovery`
+- Templates are represented as projects with `is_template = true` (usually with `user_id = NULL`) and are listed via `GET /api/templates`
+- Cloning a template creates a new row with `is_template = false`, new `share_slug`, copied diagram/outputs, and empty `chat_history`
 - Discovery projects use `project_mode = discovery`; generation start transitions to `project_mode = default`
 - `nodes` and `edges` are always in sync (all edges reference node IDs that exist)
 - `thumbnail_url` is generated asynchronously post-`done` event; may be NULL until thumbnail completes

--- a/documents/plans/2026-03-18-issue-70-template-clone-plan.md
+++ b/documents/plans/2026-03-18-issue-70-template-clone-plan.md
@@ -1,0 +1,60 @@
+# Issue #70 Template Clone Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a “Start from template” flow on dashboard New Generation, including template listing, authenticated cloning, quota-aware gating, and redirect to a fully populated project.
+
+**Architecture:** Add a database flag (`is_template`) to mark template projects. Expose backend endpoints to list templates and clone one into a user-owned completed project while enforcing auth and quota behavior. On frontend, replace direct new-generation navigation with a modal that offers Custom vs Template and handles clone+redirect UX.
+
+**Tech Stack:** Supabase SQL migrations, FastAPI (Python 3.12), Next.js 14 + Tailwind + Radix Dialog, pytest, vitest.
+
+---
+
+### Task 1: DB + Backend template API surface
+
+**Files:**
+- Create: `supabase/migrations/010_project_templates.sql`
+- Modify: `backend/project_store.py`
+- Modify: `backend/main.py`
+- Test: `backend/tests/test_templates_endpoint.py`
+
+- [ ] Step 1: Write failing backend tests for GET templates and clone auth/error/success paths.
+- [ ] Step 2: Run `cd backend && uv run pytest tests/test_templates_endpoint.py -q` and confirm failures.
+- [ ] Step 3: Implement migration + project_store helpers + FastAPI endpoints with response models.
+- [ ] Step 4: Re-run `cd backend && uv run pytest tests/test_templates_endpoint.py -q` and confirm pass.
+
+### Task 2: Frontend template client helpers
+
+**Files:**
+- Create: `frontend/lib/templates.ts`
+- Test: `frontend/lib/__tests__/templates.test.ts`
+
+- [ ] Step 1: Write failing vitest tests for response parsing and request payload handling.
+- [ ] Step 2: Run `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts` and confirm failures.
+- [ ] Step 3: Implement template list + clone helpers using existing auth token pattern.
+- [ ] Step 4: Re-run `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts` and confirm pass.
+
+### Task 3: Dashboard modal + quota/button behavior
+
+**Files:**
+- Create: `frontend/components/ProjectsDashboard/NewGenerationDialog.tsx`
+- Modify: `frontend/components/ProjectsDashboard/index.tsx`
+- Modify: `frontend/app/page.tsx`
+
+- [ ] Step 1: Add component-level logic and state wiring to open modal from New Generation.
+- [ ] Step 2: Implement Custom path (`/new`) and Template path (fetch cards, clone, loading, redirect).
+- [ ] Step 3: Apply quota gate on button: disable for non-admin/no-BYOK when quota is 0, show “No remaining quota”.
+- [ ] Step 4: Run `cd frontend && pnpm lint` to verify TS/ESLint correctness.
+
+### Task 4: Documentation and verification
+
+**Files:**
+- Modify: `documents/platform-docs.md`
+- Modify: `documents/data-reference.md`
+
+- [ ] Step 1: Document new endpoints and template data behavior.
+- [ ] Step 2: Run focused backend/frontend tests plus lint:
+  - `cd backend && uv run pytest tests/test_templates_endpoint.py tests/test_project_store.py -q`
+  - `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
+  - `cd frontend && pnpm lint`
+- [ ] Step 3: Run quick git diff sanity check.

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -252,6 +252,8 @@ Conducts a structured interview to gather application context before generation.
 |--------|------|-------------|
 | GET | `/health` | Returns `{ "status": "ok" }` |
 | GET | `/health/ready` | Returns 200 when Supabase is reachable; 503 otherwise (load balancer probe) |
+| GET | `/api/templates` | Returns public template metadata (`title`, `share_slug`, `thumbnail_url`) for the dashboard modal |
+| POST | `/api/templates/{slug}/clone` | Auth-required clone of a template into a new user-owned `completed` project; returns `{ share_slug }` |
 | POST | `/api/generations/discovery-start` | Create or resume a discovery-mode project and return canonical `project_id` + `share_slug` |
 | POST | `/api/generations/start` | Start a new generation (auth required; returns `project_id`, `trace_id`) |
 | GET | `/api/me/entitlements` | Returns `{ is_admin: bool }` for the authenticated user |

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import ApiKeyModal from "@/components/ApiKeyModal";
 import ProjectsDashboard from "@/components/ProjectsDashboard";
+import NewGenerationDialog from "@/components/ProjectsDashboard/NewGenerationDialog";
 import { useApiKeyModal } from "@/components/ApiKeyModal/useApiKeyModal";
 import { useAuth } from "@/components/auth/useAuth";
 import { fetchUserEntitlements } from "@/lib/entitlements";
@@ -22,6 +23,7 @@ export default function Home() {
   const [projects, setProjects] = useState<PersistedProject[]>([]);
   const [initialLoading, setInitialLoading] = useState(true);
   const [openError, setOpenError] = useState<string | null>(null);
+  const [newGenerationDialogOpen, setNewGenerationDialogOpen] = useState(false);
 
   const [isAdmin, setIsAdmin] = useState(false);
   const [entitlementsLoading, setEntitlementsLoading] = useState(true);
@@ -110,7 +112,17 @@ export default function Home() {
 
   function handleNewGeneration() {
     setOpenError(null);
+    setNewGenerationDialogOpen(true);
+  }
+
+  function handleCustomGeneration() {
+    setNewGenerationDialogOpen(false);
     router.push("/new");
+  }
+
+  function handleTemplateCloned(shareSlug: string) {
+    setNewGenerationDialogOpen(false);
+    router.push(`/p/${shareSlug}`);
   }
 
   if (initialLoading) {
@@ -142,6 +154,12 @@ export default function Home() {
         onConfirmDelete={confirmDelete}
         onCancelDelete={cancelDelete}
         navigationError={openError}
+      />
+      <NewGenerationDialog
+        open={newGenerationDialogOpen}
+        onClose={() => { setNewGenerationDialogOpen(false); }}
+        onCustom={handleCustomGeneration}
+        onTemplateCloned={handleTemplateCloned}
       />
       <ApiKeyModal {...apiKeyModal} />
     </>

--- a/frontend/components/ProjectsDashboard/EmptyState.tsx
+++ b/frontend/components/ProjectsDashboard/EmptyState.tsx
@@ -4,9 +4,15 @@ import { FolderKanban, Plus } from "lucide-react";
 
 type Props = {
   onNewGeneration: () => void;
+  isNewGenerationDisabled?: boolean;
+  disabledLabel?: string | null;
 };
 
-export default function EmptyState({ onNewGeneration }: Props) {
+export default function EmptyState({
+  onNewGeneration,
+  isNewGenerationDisabled = false,
+  disabledLabel = null,
+}: Props) {
   return (
     <div className="rounded-2xl border border-gray-800 bg-gray-900/60 px-8 py-16 text-center">
       <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-500/10 text-blue-300">
@@ -19,11 +25,15 @@ export default function EmptyState({ onNewGeneration }: Props) {
       <button
         type="button"
         onClick={onNewGeneration}
-        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-6 py-3 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
+        disabled={isNewGenerationDisabled}
+        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-6 py-3 text-sm font-medium text-white hover:bg-blue-500 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Plus size={16} />
         New Generation
       </button>
+      {isNewGenerationDisabled && disabledLabel && (
+        <p className="mt-3 text-xs text-amber-300">{disabledLabel}</p>
+      )}
     </div>
   );
 }

--- a/frontend/components/ProjectsDashboard/NewGenerationDialog.tsx
+++ b/frontend/components/ProjectsDashboard/NewGenerationDialog.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Loader2 } from "lucide-react";
+import { cloneTemplate, fetchTemplates, TemplateSummary } from "@/lib/templates";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCustom: () => void;
+  onTemplateCloned: (shareSlug: string) => void;
+};
+
+type ViewMode = "choices" | "templates";
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return "Something went wrong. Please try again.";
+}
+
+export default function NewGenerationDialog({ open, onClose, onCustom, onTemplateCloned }: Props) {
+  const [mode, setMode] = useState<ViewMode>("choices");
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [cloningSlug, setCloningSlug] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setMode("choices");
+      setError(null);
+      setTemplatesLoading(false);
+      setCloningSlug(null);
+    }
+  }, [open]);
+
+  async function handleShowTemplates() {
+    setMode("templates");
+    setError(null);
+    if (templates.length > 0) return;
+
+    setTemplatesLoading(true);
+    try {
+      setTemplates(await fetchTemplates());
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setTemplatesLoading(false);
+    }
+  }
+
+  async function handleClone(templateSlug: string) {
+    setError(null);
+    setCloningSlug(templateSlug);
+    try {
+      const result = await cloneTemplate(templateSlug);
+      onTemplateCloned(result.share_slug);
+    } catch (err) {
+      setError(errorMessage(err));
+      setCloningSlug(null);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => { if (!next && !cloningSlug) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-3xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-gray-700 bg-gray-900 p-6 shadow-2xl"
+          onEscapeKeyDown={(e) => { if (cloningSlug) e.preventDefault(); }}
+          onInteractOutside={(e) => { if (cloningSlug) e.preventDefault(); }}
+        >
+          <Dialog.Title className="text-lg font-semibold text-white">Start New Generation</Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-gray-400">
+            Choose how you want to begin your next architecture project.
+          </Dialog.Description>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={handleShowTemplates}
+              disabled={templatesLoading || cloningSlug !== null}
+              className="rounded-xl border border-gray-700 bg-gray-800 px-4 py-4 text-left transition-colors hover:border-gray-600 hover:bg-gray-700 disabled:opacity-50"
+            >
+              <p className="font-medium text-white">Start from template</p>
+              <p className="mt-1 text-sm text-gray-400">Pick a ready architecture and customize it in chat.</p>
+            </button>
+            <button
+              type="button"
+              onClick={onCustom}
+              disabled={cloningSlug !== null}
+              className="rounded-xl border border-blue-500/40 bg-blue-500/10 px-4 py-4 text-left transition-colors hover:border-blue-500/70 hover:bg-blue-500/15 disabled:opacity-50"
+            >
+              <p className="font-medium text-blue-200">Custom</p>
+              <p className="mt-1 text-sm text-blue-100/80">Start from scratch with the questionnaire.</p>
+            </button>
+          </div>
+
+          {mode === "templates" && (
+            <div className="mt-5 border-t border-gray-800 pt-5">
+              {templatesLoading ? (
+                <div className="flex items-center gap-2 text-sm text-gray-300">
+                  <Loader2 size={14} className="animate-spin" />
+                  Loading templates...
+                </div>
+              ) : templates.length === 0 ? (
+                <p className="text-sm text-gray-400">No templates are available yet.</p>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {templates.map((template) => {
+                    const isCloning = cloningSlug === template.share_slug;
+                    return (
+                      <button
+                        key={template.share_slug}
+                        type="button"
+                        onClick={() => { void handleClone(template.share_slug); }}
+                        disabled={cloningSlug !== null}
+                        className="overflow-hidden rounded-xl border border-gray-700 bg-gray-800 text-left transition-colors hover:border-blue-500/60 disabled:opacity-70"
+                      >
+                        <div className="relative h-[120px] w-full bg-gray-900">
+                          {template.thumbnail_url ? (
+                            <Image src={template.thumbnail_url} alt={template.title} fill className="object-cover" sizes="(max-width: 1024px) 50vw, 33vw" />
+                          ) : null}
+                          {isCloning && (
+                            <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-sm text-white">
+                              <Loader2 size={14} className="mr-2 animate-spin" />
+                              Cloning...
+                            </div>
+                          )}
+                        </div>
+                        <div className="px-4 py-3">
+                          <p className="text-sm font-medium text-white">{template.title}</p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {error && <p className="mt-4 text-sm text-red-300">{error}</p>}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/components/ProjectsDashboard/index.tsx
+++ b/frontend/components/ProjectsDashboard/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Key, Plus, Settings } from "lucide-react";
+import { Plus, Settings } from "lucide-react";
 import UserMenu from "@/components/UserMenu";
 import type { ProjectSummary } from "@/lib/projects";
 import DeleteProjectDialog from "./DeleteProjectDialog";
@@ -43,20 +42,16 @@ export default function ProjectsDashboard({
   onCancelDelete,
   navigationError = null,
 }: Props) {
-  const [showQuotaPrompt, setShowQuotaPrompt] = useState(false);
-
   const quotaLabel = quotaLoading
     ? "Checking quota..."
     : isAdmin
       ? "Unlimited generations"
       : `${remainingGenerations}/${generationLimit} generations remaining`;
+  const isQuotaExhausted = !isAdmin && !hasApiKey && !quotaLoading && remainingGenerations === 0;
+  const quotaExhaustedLabel = isQuotaExhausted ? "No remaining quota" : null;
 
   function handleNewGeneration() {
-    if (!isAdmin && remainingGenerations === 0 && !hasApiKey) {
-      setShowQuotaPrompt(true);
-      return;
-    }
-    setShowQuotaPrompt(false);
+    if (isQuotaExhausted) return;
     onNewGeneration();
   }
   const pendingDeleteTitle = pendingDeleteId
@@ -94,36 +89,28 @@ export default function ProjectsDashboard({
             {navigationError}
           </div>
         )}
-        {showQuotaPrompt && (
-          <div className="mb-6 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-4">
-            <p className="mb-2 text-sm text-amber-200">
-              You have used all your free generations. Add your own API key for unlimited generations.
-            </p>
-            <button
-              type="button"
-              onClick={() => { setShowQuotaPrompt(false); onOpenSettings(); }}
-              className="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-500 transition-colors"
-            >
-              <Key size={14} />
-              Add API Key
-            </button>
-          </div>
-        )}
-
         <div className="mb-8 flex items-center justify-between gap-3">
           <h2 className="text-sm font-medium uppercase tracking-wider text-gray-400">Generation History</h2>
-          <button
-            type="button"
-            onClick={handleNewGeneration}
-            className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
-          >
-            <Plus size={16} />
-            New Generation
-          </button>
+          <div className="flex flex-col items-end gap-1">
+            <button
+              type="button"
+              onClick={handleNewGeneration}
+              disabled={isQuotaExhausted}
+              className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-500 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus size={16} />
+              New Generation
+            </button>
+            {quotaExhaustedLabel && <p className="text-xs text-amber-300">{quotaExhaustedLabel}</p>}
+          </div>
         </div>
 
         {projects.length === 0 ? (
-          <EmptyState onNewGeneration={handleNewGeneration} />
+          <EmptyState
+            onNewGeneration={handleNewGeneration}
+            isNewGenerationDisabled={isQuotaExhausted}
+            disabledLabel={quotaExhaustedLabel}
+          />
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (

--- a/frontend/lib/__tests__/templates.test.ts
+++ b/frontend/lib/__tests__/templates.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseCloneTemplateResponse, parseTemplatesResponse } from "../templates";
+
+describe("template API response parsers", () => {
+  it("parses valid template list payload", () => {
+    const parsed = parseTemplatesResponse([
+      { title: "ECS + RDS", share_slug: "tmpl0001", thumbnail_url: "https://cdn.example/t1.png" },
+      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null },
+    ]);
+
+    expect(parsed).toEqual([
+      { title: "ECS + RDS", share_slug: "tmpl0001", thumbnail_url: "https://cdn.example/t1.png" },
+      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null },
+    ]);
+  });
+
+  it("filters malformed template rows", () => {
+    const parsed = parseTemplatesResponse([
+      { title: "Valid", share_slug: "tmpl0001", thumbnail_url: null },
+      { title: "Missing slug" },
+      "invalid",
+    ]);
+
+    expect(parsed).toEqual([{ title: "Valid", share_slug: "tmpl0001", thumbnail_url: null }]);
+  });
+
+  it("parses valid clone response", () => {
+    expect(parseCloneTemplateResponse({ share_slug: "clone0001" })).toEqual({ share_slug: "clone0001" });
+  });
+
+  it("returns null for invalid clone response", () => {
+    expect(parseCloneTemplateResponse({})).toBeNull();
+    expect(parseCloneTemplateResponse("nope")).toBeNull();
+  });
+});

--- a/frontend/lib/templates.ts
+++ b/frontend/lib/templates.ts
@@ -1,0 +1,78 @@
+import { withAccessToken } from "./generationStart";
+
+export type TemplateSummary = {
+  title: string;
+  share_slug: string;
+  thumbnail_url: string | null;
+};
+
+export type CloneTemplateResponse = {
+  share_slug: string;
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+type ErrorDetail = { detail?: { error?: string; message?: string } };
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function parseErrorMessage(body: unknown): string {
+  const detail = (body as ErrorDetail).detail;
+  if (detail?.message) return detail.message;
+  if (detail?.error) return detail.error;
+  return "Request failed";
+}
+
+export function parseTemplatesResponse(body: unknown): TemplateSummary[] {
+  if (!Array.isArray(body)) return [];
+
+  return body
+    .filter(isRecord)
+    .flatMap((item) => {
+      if (typeof item.title !== "string" || !item.title.trim()) return [];
+      if (typeof item.share_slug !== "string" || !item.share_slug.trim()) return [];
+      const thumbnail_url = typeof item.thumbnail_url === "string" && item.thumbnail_url.trim()
+        ? item.thumbnail_url
+        : null;
+      return [{ title: item.title.trim(), share_slug: item.share_slug.trim(), thumbnail_url }];
+    });
+}
+
+export function parseCloneTemplateResponse(body: unknown): CloneTemplateResponse | null {
+  if (!isRecord(body)) return null;
+  if (typeof body.share_slug !== "string" || !body.share_slug.trim()) return null;
+  return { share_slug: body.share_slug.trim() };
+}
+
+export async function fetchTemplates(): Promise<TemplateSummary[]> {
+  const response = await fetch(`${API_URL}/api/templates`);
+  const body = (await response.json().catch(() => [])) as unknown;
+
+  if (!response.ok) {
+    throw new Error(parseErrorMessage(body));
+  }
+  return parseTemplatesResponse(body);
+}
+
+export async function cloneTemplate(templateSlug: string): Promise<CloneTemplateResponse> {
+  const payload = await withAccessToken({});
+  const response = await fetch(`${API_URL}/api/templates/${encodeURIComponent(templateSlug)}/clone`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = (await response.json().catch(() => ({}))) as unknown;
+
+  if (!response.ok) {
+    throw new Error(parseErrorMessage(body));
+  }
+
+  const parsed = parseCloneTemplateResponse(body);
+  if (!parsed) {
+    throw new Error("Template clone endpoint returned an invalid payload.");
+  }
+  return parsed;
+}

--- a/supabase/migrations/010_project_templates.sql
+++ b/supabase/migrations/010_project_templates.sql
@@ -1,0 +1,5 @@
+alter table if exists projects
+  add column if not exists is_template boolean not null default false;
+
+create index if not exists idx_projects_is_template
+  on projects (is_template);


### PR DESCRIPTION
## Summary
- add template support to projects (`is_template`) plus backend template listing and clone endpoints
- implement dashboard New Generation modal with "Start from template" and "Custom" paths
- clone templates into completed user-owned projects with quota/BYOK/admin handling and redirect to `/p/{new-slug}`
- disable New Generation when quota is exhausted for non-admin users without BYOK, showing "No remaining quota"
- update platform/data docs for new APIs and template model

## Test Plan
- cd backend && uv run pytest tests/test_templates_endpoint.py tests/test_project_store.py tests/test_generation_start_endpoint.py -q
- cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts lib/__tests__/generationStart.test.ts lib/__tests__/projects.test.ts
- cd frontend && pnpm lint

Closes #70