### PR TITLE
Auto-layout diagram when architect agent completes

### DIFF
--- a/frontend/lib/__tests__/pipelineLayout.test.ts
+++ b/frontend/lib/__tests__/pipelineLayout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldApplyLayoutOnPipelineEvent } from "../pipelineLayout";
+
+describe("shouldApplyLayoutOnPipelineEvent", () => {
+  it("returns true when architect stage completes", () => {
+    expect(shouldApplyLayoutOnPipelineEvent("architect", "completed")).toBe(true);
+  });
+
+  it("returns false for non-completion architect events", () => {
+    expect(shouldApplyLayoutOnPipelineEvent("architect", "started")).toBe(false);
+  });
+
+  it("returns false for other stages", () => {
+    expect(shouldApplyLayoutOnPipelineEvent("coder", "completed")).toBe(false);
+  });
+});

--- a/frontend/lib/pipelineLayout.ts
+++ b/frontend/lib/pipelineLayout.ts
@@ -1,0 +1,3 @@
+export function shouldApplyLayoutOnPipelineEvent(stage: string | null, eventName: string | null): boolean {
+  return stage === "architect" && eventName === "completed";
+}

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -18,6 +18,7 @@ import {
   SetupPdfStatus,
 } from "@/lib/setupPdf";
 import type { GraphMutationPayload } from "@/lib/graphDiff";
+import { shouldApplyLayoutOnPipelineEvent } from "./pipelineLayout";
 import { shouldHydrateFromProject } from "./canvasHydration";
 
 export type AgentLogEntry = {
@@ -767,6 +768,10 @@ export function useCanvasPipeline(
               lastUpdateAt: Date.now(),
             };
           });
+        }
+
+        if (shouldApplyLayoutOnPipelineEvent(stage, eventName)) {
+          applyLayout();
         }
 
         if (level === "error") {


### PR DESCRIPTION
## Summary
- trigger auto-layout when a `pipeline_event` arrives with stage `architect` and event `completed`
- keep final `done` auto-layout behavior unchanged
- add regression tests for the architect-completed layout predicate

## Test Plan
- [x] pnpm --dir frontend exec vitest run lib/__tests__/pipelineLayout.test.ts
- [x] pnpm --dir frontend exec vitest run lib/__tests__

Closes #81
