### PR TITLE
fix: add structured observability logging across backend agents

### DIFF
--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 import logging
+import time
 from typing import Any
 
 from llm_client import async_stream_text
@@ -44,15 +45,28 @@ async def stream_architecture(
     start_time: float = 0,
     llm_creds: dict[str, Any] | None = None,
 ) -> None:
-    await emit_log(websocket, "architect", "Designing architecture...", start_time)
+    raw_trace = getattr(websocket, "trace_id", None)
+    trace_id = raw_trace.strip() if isinstance(raw_trace, str) and raw_trace.strip() else None
+    await emit_log(websocket, "architect", "Designing architecture...", start_time, trace_id=trace_id)
+    logger.info("architect.started trace_id=%s", trace_id)
     buffer = ""
     first_node_emitted = False
     consecutive_bad_lines = 0
+    node_count = 0
+    edge_count = 0
+    last_valid_line_at = time.monotonic()
+    stall_warned = False
     async for chunk in async_stream_text(
         messages=[{"role": "user", "content": json.dumps(requirements)}],
         system=ARCHITECT_SYSTEM,
         llm_creds=llm_creds,
+        log_context={"agent": "architect", "trace_id": trace_id},
     ):
+        if first_node_emitted:
+            now = time.monotonic()
+            if now - last_valid_line_at > 10 and not stall_warned:
+                stall_warned = True
+                logger.warning("architect.stall_warning trace_id=%s idle_seconds=%d", trace_id, int(now - last_valid_line_at))
         buffer += chunk
         while "\n" in buffer:
             line, buffer = buffer.split("\n", 1)
@@ -62,13 +76,28 @@ async def stream_architecture(
             try:
                 event = json.loads(line)
                 await websocket.send_text(json.dumps({"type": "diagram_event", **event}))
+                last_valid_line_at = time.monotonic()
+                stall_warned = False
                 if event.get("action") == "add_node":
                     first_node_emitted = True
                     consecutive_bad_lines = 0
+                    node_count += 1
                     await emit_log(
                         websocket, "architect",
                         f"Added {event['label']} ({event.get('category', '')})",
                         start_time,
+                        trace_id=trace_id,
+                    )
+                elif event.get("action") == "add_edge":
+                    edge_count += 1
+                    source = event.get("from")
+                    target = event.get("to")
+                    await emit_log(
+                        websocket,
+                        "architect",
+                        f"Connected {source} -> {target}",
+                        start_time,
+                        trace_id=trace_id,
                     )
                 else:
                     consecutive_bad_lines = 0
@@ -90,4 +119,12 @@ async def stream_architecture(
                         raise RuntimeError(
                             f"Architect agent emitted {consecutive_bad_lines} consecutive non-JSON lines; aborting."
                         )
-    await emit_log(websocket, "architect", "Architecture complete", start_time)
+    await emit_log(
+        websocket,
+        "architect",
+        f"Architecture complete ({node_count} nodes, {edge_count} edges)",
+        start_time,
+        trace_id=trace_id,
+        details={"nodes": node_count, "edges": edge_count},
+    )
+    logger.info("architect.completed trace_id=%s nodes=%d edges=%d", trace_id, node_count, edge_count)

--- a/backend/agents/coder.py
+++ b/backend/agents/coder.py
@@ -111,8 +111,10 @@ async def _emit_terraform_file_with_progress(
     file_payload: dict,
     emitted_count: int,
     start_time: float,
+    trace_id: str | None = None,
 ) -> None:
     filename = str(file_payload.get("filename") or f"file-{emitted_count}.tf")
+    logger.info("coder.file_started trace_id=%s file=%s index=%d", trace_id, filename, emitted_count)
     await websocket.send_text(
         json.dumps(
             {
@@ -123,7 +125,7 @@ async def _emit_terraform_file_with_progress(
             }
         )
     )
-    await emit_log(websocket, "coder", f"Writing {filename}", start_time)
+    await emit_log(websocket, "coder", f"Writing {filename}", start_time, trace_id=trace_id)
 
     event_name = "coder.first_file_emitted" if emitted_count == 1 else "coder.file_emitted"
     await _emit_coder_event(
@@ -138,6 +140,7 @@ async def _emit_terraform_file_with_progress(
             "activity": f"Generating {filename}",
         },
     )
+    logger.info("coder.file_emitted trace_id=%s file=%s index=%d", trace_id, filename, emitted_count)
     await asyncio.sleep(0.15)
 
 
@@ -150,7 +153,10 @@ async def stream_terraform_files(
     llm_creds: dict[str, Any] | None = None,
 ) -> None:
     start_loop_time = asyncio.get_running_loop().time()
-    await emit_log(websocket, "coder", "Generating Terraform...", start_time)
+    raw_trace = getattr(websocket, "trace_id", None)
+    trace_id = raw_trace.strip() if isinstance(raw_trace, str) and raw_trace.strip() else None
+    logger.info("coder.started trace_id=%s", trace_id)
+    await emit_log(websocket, "coder", "Generating Terraform...", start_time, trace_id=trace_id)
     await _emit_coder_event(
         websocket,
         "coder.started",
@@ -177,8 +183,10 @@ async def stream_terraform_files(
                 api_key=api_key,
                 start_time=start_time,
                 start_loop_time=start_loop_time,
+                trace_id=trace_id,
             )
         except asyncio.TimeoutError:
+            logger.warning("coder.timeout_fallback trace_id=%s reason=tool_use_timeout", trace_id)
             await _emit_coder_event(
                 websocket,
                 "coder.timeout_fallback",
@@ -194,9 +202,14 @@ async def stream_terraform_files(
                 start_loop_time,
                 fallback=True,
                 llm_creds=llm_creds,
+                trace_id=trace_id,
             )
         except Exception:
-            logger.error("Coder tool-use path failed unexpectedly, falling back to JSON", exc_info=True)
+            logger.error(
+                "Coder tool-use path failed unexpectedly, falling back to JSON trace_id=%s",
+                trace_id,
+                exc_info=True,
+            )
             await _emit_coder_event(
                 websocket,
                 "coder.parse_fallback",
@@ -212,9 +225,11 @@ async def stream_terraform_files(
                 start_loop_time,
                 fallback=True,
                 llm_creds=llm_creds,
+                trace_id=trace_id,
             )
 
         if emitted_count == 0:
+            logger.warning("coder.parse_fallback trace_id=%s reason=no_files_emitted", trace_id)
             await _emit_coder_event(
                 websocket,
                 "coder.parse_fallback",
@@ -230,6 +245,7 @@ async def stream_terraform_files(
                 start_loop_time,
                 fallback=True,
                 llm_creds=llm_creds,
+                trace_id=trace_id,
             )
     else:
         emitted_count = await _stream_via_json_complete(
@@ -238,6 +254,7 @@ async def stream_terraform_files(
             start_time,
             start_loop_time,
             llm_creds=llm_creds,
+            trace_id=trace_id,
         )
 
     await _emit_coder_event(
@@ -251,7 +268,8 @@ async def stream_terraform_files(
             "expected_min_files": EXPECTED_MIN_FILES,
         },
     )
-    await emit_log(websocket, "coder", "Terraform ready", start_time)
+    logger.info("coder.completed trace_id=%s emitted_count=%d", trace_id, emitted_count)
+    await emit_log(websocket, "coder", "Terraform ready", start_time, trace_id=trace_id)
 
 
 async def _stream_via_tool_use(
@@ -261,6 +279,7 @@ async def _stream_via_tool_use(
     api_key: str,
     start_time: float = 0,
     start_loop_time: float = 0,
+    trace_id: str | None = None,
 ) -> int:
     import anthropic
 
@@ -285,12 +304,13 @@ async def _stream_via_tool_use(
     for block in response.content:
         if block.type == "tool_use" and block.name == "emit_terraform_file":
             emitted_count += 1
-            await _emit_terraform_file_with_progress(websocket, block.input, emitted_count, start_time)
+            await _emit_terraform_file_with_progress(websocket, block.input, emitted_count, start_time, trace_id)
 
     if response.stop_reason == "max_tokens":
         logger.warning(
-            "Coder tool-use response truncated (stop_reason=max_tokens), emitted %d files",
+            "Coder tool-use response truncated (stop_reason=max_tokens), emitted %d files trace_id=%s",
             emitted_count,
+            trace_id,
         )
 
     return emitted_count
@@ -303,6 +323,7 @@ async def _stream_via_json_complete(
     start_loop_time: float = 0,
     fallback: bool = False,
     llm_creds: dict[str, Any] | None = None,
+    trace_id: str | None = None,
 ) -> int:
     await _emit_coder_event(
         websocket,
@@ -321,10 +342,12 @@ async def _stream_via_json_complete(
                 system="Output valid JSON only. No prose, no markdown fences.",
                 llm_creds=llm_creds,
                 max_tokens=ANTHROPIC_MAX_TOKENS,
+                log_context={"agent": "coder", "trace_id": trace_id},
             ),
             timeout=FALLBACK_REQUEST_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
+        logger.warning("coder.json_timeout trace_id=%s fallback=%s", trace_id, fallback)
         await _emit_coder_event(
             websocket,
             "coder.timeout_fallback",
@@ -340,6 +363,7 @@ async def _stream_via_json_complete(
     try:
         files = json.loads(raw)
     except json.JSONDecodeError as error:
+        logger.warning("coder.json_parse_failed trace_id=%s fallback=%s", trace_id, fallback)
         await _emit_coder_event(
             websocket,
             "coder.parse_fallback",
@@ -355,5 +379,5 @@ async def _stream_via_json_complete(
         if not isinstance(file, dict):
             continue
         emitted_count += 1
-        await _emit_terraform_file_with_progress(websocket, file, emitted_count, start_time)
+        await _emit_terraform_file_with_progress(websocket, file, emitted_count, start_time, trace_id)
     return emitted_count

--- a/backend/agents/cost_analyst.py
+++ b/backend/agents/cost_analyst.py
@@ -4,6 +4,7 @@ import logging
 import subprocess
 import tempfile
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -57,7 +58,11 @@ async def run_cost_analyst(
     diagram_nodes: list | None = None,
     llm_creds: dict[str, Any] | None = None,
 ) -> None:
-    await emit_log(websocket, "cost_analyst", "Estimating costs...", start_time)
+    started = time.monotonic()
+    raw_trace = getattr(websocket, "trace_id", None)
+    trace_id = raw_trace.strip() if isinstance(raw_trace, str) and raw_trace.strip() else None
+    logger.info("cost_analyst.started trace_id=%s", trace_id)
+    await emit_log(websocket, "cost_analyst", "Estimating costs...", start_time, trace_id=trace_id)
     await websocket.send_text(json.dumps({
         "type": "cost_status",
         "message": "Generating cost estimate...",
@@ -67,24 +72,33 @@ async def run_cost_analyst(
 
     try:
         # Step 1: Generate minimal HCL
+        hcl_started = time.monotonic()
         raw_hcl = await asyncio.wait_for(
             async_complete(
                 messages=[{"role": "user", "content": json.dumps(enriched, indent=2)}],
                 system=COST_HCL_SYSTEM,
                 llm_creds=llm_creds,
+                log_context={"agent": "cost_analyst", "trace_id": trace_id},
             ),
             timeout=PRIMARY_HCL_TIMEOUT_SECONDS,
         )
         raw_hcl = raw_hcl.strip()
         if raw_hcl.startswith("```"):
             raw_hcl = raw_hcl.split("\n", 1)[1].rsplit("```", 1)[0]
+        logger.info(
+            "cost_analyst.hcl_generated trace_id=%s duration_ms=%d chars=%d",
+            trace_id,
+            int((time.monotonic() - hcl_started) * 1000),
+            len(raw_hcl),
+        )
 
         # Step 2: Write to temp dir and run infracost
-        await emit_log(websocket, "cost_analyst", "Calling Infracost API", start_time)
+        await emit_log(websocket, "cost_analyst", "Calling Infracost API", start_time, trace_id=trace_id)
         with tempfile.TemporaryDirectory() as tmpdir:
             tf_path = Path(tmpdir) / "main.tf"
             tf_path.write_text(raw_hcl)
 
+            subprocess_started = time.monotonic()
             result = await asyncio.to_thread(
                 subprocess.run,
                 ["infracost", "breakdown", "--path", str(tmpdir),
@@ -94,8 +108,19 @@ async def run_cost_analyst(
                 timeout=120,
                 env={**os.environ},
             )
+            logger.info(
+                "cost_analyst.infracost_completed trace_id=%s duration_ms=%d return_code=%s",
+                trace_id,
+                int((time.monotonic() - subprocess_started) * 1000),
+                result.returncode,
+            )
 
             if result.returncode != 0:
+                logger.warning(
+                    "cost_analyst.infracost_failed trace_id=%s return_code=%s",
+                    trace_id,
+                    result.returncode,
+                )
                 raise RuntimeError(f"infracost failed: {result.stderr[:200]}")
 
             cost_data = json.loads(result.stdout)
@@ -105,10 +130,20 @@ async def run_cost_analyst(
             "type": "cost_estimate",
             "data": breakdown,
         }))
-        await emit_log(websocket, "cost_analyst", "Cost estimate ready", start_time)
+        logger.info(
+            "cost_analyst.completed trace_id=%s duration_ms=%d monthly_total=%s",
+            trace_id,
+            int((time.monotonic() - started) * 1000),
+            breakdown.get("monthly_total") if isinstance(breakdown, dict) else None,
+        )
+        await emit_log(websocket, "cost_analyst", "Cost estimate ready", start_time, trace_id=trace_id)
 
     except asyncio.TimeoutError:
-        logger.warning("Cost analyst primary LLM call timed out, using AI estimate fallback", exc_info=True)
+        logger.warning(
+            "Cost analyst primary LLM call timed out, using AI estimate fallback trace_id=%s",
+            trace_id,
+            exc_info=True,
+        )
         await websocket.send_text(json.dumps({
             "type": "pipeline_event",
             "stage": "cost_analyst",
@@ -116,9 +151,9 @@ async def run_cost_analyst(
             "level": "warning",
             "message": "Cost analyst timed out while generating HCL; using AI estimate fallback.",
         }))
-        await _send_estimated_costs(enriched, websocket, start_time, llm_creds=llm_creds)
+        await _send_estimated_costs(enriched, websocket, start_time, llm_creds=llm_creds, trace_id=trace_id)
     except Exception:
-        logger.warning("Infracost failed, using AI estimate fallback", exc_info=True)
+        logger.warning("Infracost failed, using AI estimate fallback trace_id=%s", trace_id, exc_info=True)
         await websocket.send_text(json.dumps({
             "type": "pipeline_event",
             "stage": "cost_analyst",
@@ -126,7 +161,7 @@ async def run_cost_analyst(
             "level": "warning",
             "message": "Infracost failed, using AI estimate fallback.",
         }))
-        await _send_estimated_costs(enriched, websocket, start_time, llm_creds=llm_creds)
+        await _send_estimated_costs(enriched, websocket, start_time, llm_creds=llm_creds, trace_id=trace_id)
 
 
 def _parse_infracost_output(data: dict) -> dict:
@@ -160,8 +195,10 @@ async def _send_estimated_costs(
     websocket,
     start_time: float = 0,
     llm_creds: dict[str, Any] | None = None,
+    trace_id: str | None = None,
 ) -> None:
-    await emit_log(websocket, "cost_analyst", "Using AI cost estimation", start_time)
+    fallback_started = time.monotonic()
+    await emit_log(websocket, "cost_analyst", "Using AI cost estimation", start_time, trace_id=trace_id)
     prompt = "Estimate monthly AWS costs for this architecture:\n" + json.dumps(requirements)
     try:
         raw = await asyncio.wait_for(
@@ -169,10 +206,16 @@ async def _send_estimated_costs(
                 messages=[{"role": "user", "content": prompt}],
                 system=COST_ESTIMATE_SYSTEM,
                 llm_creds=llm_creds,
+                log_context={"agent": "cost_analyst", "trace_id": trace_id},
             ),
             timeout=FALLBACK_ESTIMATE_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
+        logger.warning(
+            "cost_analyst.fallback_timeout trace_id=%s duration_ms=%d",
+            trace_id,
+            int((time.monotonic() - fallback_started) * 1000),
+        )
         await websocket.send_text(json.dumps({
             "type": "pipeline_event",
             "stage": "cost_analyst",
@@ -198,8 +241,15 @@ async def _send_estimated_costs(
     try:
         data = _apply_budget_warning(json.loads(raw), requirements)
         await websocket.send_text(json.dumps({"type": "cost_estimate", "data": data}))
-        await emit_log(websocket, "cost_analyst", "Cost estimate ready", start_time)
+        logger.info(
+            "cost_analyst.fallback_completed trace_id=%s duration_ms=%d monthly_total=%s",
+            trace_id,
+            int((time.monotonic() - fallback_started) * 1000),
+            data.get("monthly_total") if isinstance(data, dict) else None,
+        )
+        await emit_log(websocket, "cost_analyst", "Cost estimate ready", start_time, trace_id=trace_id)
     except Exception:
+        logger.warning("cost_analyst.fallback_parse_failed trace_id=%s", trace_id, exc_info=True)
         await websocket.send_text(json.dumps({
             "type": "cost_estimate",
             "data": {

--- a/backend/agents/description.py
+++ b/backend/agents/description.py
@@ -1,5 +1,7 @@
 import json
 import asyncio
+import logging
+import time
 from typing import Any
 
 from fastapi import WebSocket
@@ -26,6 +28,7 @@ Rules:
 """
 
 DESCRIPTION_REQUEST_TIMEOUT_SECONDS = 90
+logger = logging.getLogger(__name__)
 
 
 async def run_description_agent(
@@ -35,7 +38,17 @@ async def run_description_agent(
     diagram_nodes: list | None = None,
     llm_creds: dict[str, Any] | None = None,
 ) -> None:
-    await emit_log(websocket, "description", "Writing architecture description...", start_time)
+    started = time.monotonic()
+    raw_trace = getattr(websocket, "trace_id", None)
+    trace_id = raw_trace.strip() if isinstance(raw_trace, str) and raw_trace.strip() else None
+    logger.info("description.started trace_id=%s", trace_id)
+    await emit_log(
+        websocket,
+        "description",
+        "Writing architecture description...",
+        start_time,
+        trace_id=trace_id,
+    )
 
     if diagram_nodes:
         node_summary = [
@@ -58,10 +71,17 @@ async def run_description_agent(
                 messages=[{"role": "user", "content": prompt}],
                 system=DESCRIPTION_SYSTEM,
                 llm_creds=llm_creds,
+                log_context={"agent": "description", "trace_id": trace_id},
             ),
             timeout=DESCRIPTION_REQUEST_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
+        logger.warning(
+            "description.timeout trace_id=%s duration_ms=%d timeout_seconds=%d",
+            trace_id,
+            int((time.monotonic() - started) * 1000),
+            DESCRIPTION_REQUEST_TIMEOUT_SECONDS,
+        )
         await websocket.send_text(json.dumps({
             "type": "pipeline_event",
             "stage": "description",
@@ -81,8 +101,19 @@ async def run_description_agent(
             "type": "arch_description",
             "sections": sections,
         }))
-        await emit_log(websocket, "description", "Description ready", start_time)
+        logger.info(
+            "description.completed trace_id=%s duration_ms=%d section_count=%d",
+            trace_id,
+            int((time.monotonic() - started) * 1000),
+            len(sections) if isinstance(sections, dict) else 0,
+        )
+        await emit_log(websocket, "description", "Description ready", start_time, trace_id=trace_id)
     except (json.JSONDecodeError, Exception):
+        logger.warning(
+            "description.parse_failed trace_id=%s duration_ms=%d",
+            trace_id,
+            int((time.monotonic() - started) * 1000),
+        )
         await websocket.send_text(json.dumps({
             "type": "pipeline_event",
             "stage": "description",

--- a/backend/agents/discovery_agent.py
+++ b/backend/agents/discovery_agent.py
@@ -3,12 +3,15 @@
 Conducts a structured discovery interview to gather application context
 before starting the architecture generation pipeline.
 """
+import logging
+import time
 from typing import Any, AsyncGenerator
 
 from llm_client import async_stream_text
 
 _PLAN_START = "===ARCHITECTURE_PLAN==="
 _PLAN_END = "===END_PLAN==="
+logger = logging.getLogger(__name__)
 
 
 def _build_system_prompt(answers: dict[str, Any]) -> str:
@@ -113,23 +116,49 @@ async def stream_discovery_reply(
     history: list[dict[str, Any]],
     answers: dict[str, Any],
     llm_creds: dict[str, Any] | None = None,
+    trace_id: str | None = None,
 ) -> AsyncGenerator[tuple[str, bool], None]:
     """Stream a discovery reply chunk by chunk.
 
     Yields (chunk, is_plan_sentinel) tuples.
     The final chunk yields ("", True) when the full response contains a plan.
     """
+    started = time.monotonic()
     normalized = _normalize_history(history)
+    prior_question_count = sum(
+        1
+        for entry in normalized
+        if entry.get("role") == "assistant" and "?" in entry.get("content", "")
+    )
+    logger.info(
+        "discovery.started trace_id=%s prior_question_count=%d history_messages=%d",
+        trace_id,
+        prior_question_count,
+        len(normalized),
+    )
     messages = [*normalized, {"role": "user", "content": user_message}]
     system_prompt = _build_system_prompt(answers)
 
     chunks: list[str] = []
-    async for chunk in async_stream_text(messages=messages, system=system_prompt, llm_creds=llm_creds):
+    async for chunk in async_stream_text(
+        messages=messages,
+        system=system_prompt,
+        llm_creds=llm_creds,
+        log_context={"agent": "discovery", "trace_id": trace_id},
+    ):
         if isinstance(chunk, str) and chunk:
             chunks.append(chunk)
             yield chunk, False
 
     full_response = "".join(chunks)
     _, plan_ready = detect_plan_ready(full_response)
+    total_question_count = prior_question_count + full_response.count("?")
+    logger.info(
+        "discovery.completed trace_id=%s duration_ms=%d plan_ready=%s question_count=%d",
+        trace_id,
+        int((time.monotonic() - started) * 1000),
+        plan_ready,
+        total_question_count,
+    )
     if plan_ready:
         yield "", True

--- a/backend/agents/log_helper.py
+++ b/backend/agents/log_helper.py
@@ -1,12 +1,56 @@
 import json
+import logging
 import time
 
+logger = logging.getLogger(__name__)
 
-async def emit_log(websocket, agent: str, message: str, start_time: float) -> None:
-    elapsed = round(time.time() - start_time, 1)
-    await websocket.send_text(json.dumps({
+
+def log_agent_event(
+    agent: str,
+    event: str,
+    *,
+    level: str = "info",
+    trace_id: str | None = None,
+    duration_ms: int | None = None,
+    **fields,
+) -> None:
+    payload = {
+        "agent": agent,
+        "event": event,
+        "trace_id": trace_id,
+        "duration_ms": duration_ms,
+        **fields,
+    }
+    log_method = getattr(logger, level, logger.info)
+    log_method("agent_event %s", event, extra={"agent_event": payload})
+
+
+async def emit_log(
+    websocket,
+    agent: str,
+    message: str,
+    start_time: float,
+    *,
+    trace_id: str | None = None,
+    details: dict | None = None,
+) -> None:
+    elapsed_raw = max(time.time() - start_time, 0.0)
+    elapsed = round(elapsed_raw, 1)
+    resolved_trace_id: str | None = None
+    if isinstance(trace_id, str) and trace_id.strip():
+        resolved_trace_id = trace_id.strip()
+    else:
+        websocket_trace = getattr(websocket, "trace_id", None)
+        if isinstance(websocket_trace, str) and websocket_trace.strip():
+            resolved_trace_id = websocket_trace.strip()
+    payload = {
         "type": "agent_log",
         "agent": agent,
         "message": message,
         "elapsed": elapsed,
-    }))
+        "duration_ms": int(elapsed_raw * 1000),
+        "trace_id": resolved_trace_id,
+    }
+    if isinstance(details, dict) and details:
+        payload["details"] = details
+    await websocket.send_text(json.dumps(payload))

--- a/backend/agents/requirements.py
+++ b/backend/agents/requirements.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import time
 from typing import Any
 
 from llm_client import async_complete
@@ -51,6 +53,8 @@ Rules:
 
 Output ONLY valid JSON. No prose, no markdown fences."""
 
+logger = logging.getLogger(__name__)
+
 
 def _normalize_budget(value: Any) -> float | None:
     if isinstance(value, bool):
@@ -90,12 +94,20 @@ def _apply_budget_semantics(requirements: Any, answers: dict[str, Any]) -> Any:
     return enriched
 
 
-async def generate_requirements(answers: dict, llm_creds: dict[str, Any] | None = None) -> dict:
+async def generate_requirements(
+    answers: dict,
+    llm_creds: dict[str, Any] | None = None,
+    *,
+    trace_id: str | None = None,
+) -> dict:
+    started = time.monotonic()
+    logger.info("requirements.started trace_id=%s", trace_id)
     user_msg = "Convert these project answers into a requirements JSON:\n" + json.dumps(answers, indent=2)
     raw = await async_complete(
         messages=[{"role": "user", "content": user_msg}],
         system=SYSTEM_PROMPT,
         llm_creds=llm_creds,
+        log_context={"agent": "requirements", "trace_id": trace_id},
     )
     raw = raw.strip()
     if raw.startswith("```"):
@@ -104,5 +116,21 @@ async def generate_requirements(answers: dict, llm_creds: dict[str, Any] | None 
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as e:
+        logger.warning(
+            "requirements.parse_failed trace_id=%s duration_ms=%d error=%s",
+            trace_id,
+            int((time.monotonic() - started) * 1000),
+            str(e),
+        )
         raise ValueError(f"Requirements agent returned invalid JSON: {e}") from e
+    inferred_services = parsed.get("inferred_services") if isinstance(parsed, dict) else None
+    service_count = len(inferred_services) if isinstance(inferred_services, list) else None
+    app_name = parsed.get("app_name") if isinstance(parsed, dict) else None
+    logger.info(
+        "requirements.completed trace_id=%s duration_ms=%d app_name=%s service_count=%s",
+        trace_id,
+        int((time.monotonic() - started) * 1000),
+        app_name,
+        service_count,
+    )
     return _apply_budget_semantics(parsed, answers)

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -1188,7 +1188,11 @@ async def _generate_requirements_with_retry(
     for attempt in range(1, REQUIREMENTS_MAX_ATTEMPTS + 1):
         try:
             return await asyncio.wait_for(
-                generate_requirements(answers, llm_creds=llm_creds),
+                generate_requirements(
+                    answers,
+                    llm_creds=llm_creds,
+                    trace_id=runtime.trace_id,
+                ),
                 timeout=REQUIREMENTS_ATTEMPT_TIMEOUT_SECONDS,
             )
         except (asyncio.TimeoutError, TimeoutError) as error:

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from pathlib import Path
@@ -5,6 +6,8 @@ from typing import Any, AsyncGenerator
 
 import httpx
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 
 def _load_local_env_files() -> None:
@@ -45,8 +48,10 @@ if _ENV_CREDS is None:
     ACTIVE_PROVIDER = None
     ACTIVE_MODEL = None
     ACTIVE_KEY = None
+    logger.warning("No default LLM provider configured from environment")
 else:
     ACTIVE_PROVIDER, ACTIVE_MODEL, ACTIVE_KEY = _ENV_CREDS
+    logger.info("Detected default LLM provider provider=%s model=%s", ACTIVE_PROVIDER, ACTIVE_MODEL)
 
 PROVIDER_MODELS = {
     "anthropic": "claude-sonnet-4-20250514",
@@ -56,6 +61,16 @@ PROVIDER_MODELS = {
 
 HTTP_CLIENT_TIMEOUT = httpx.Timeout(connect=30.0, read=90.0, write=60.0, pool=60.0)
 CONTENT_STALL_TIMEOUT_SECONDS = 60.0
+STALL_WARNING_SECONDS = (30.0, 45.0)
+
+
+def _context_value(log_context: dict[str, Any] | None, key: str, default: str = "n/a") -> str:
+    if not isinstance(log_context, dict):
+        return default
+    value = log_context.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
 
 
 def _resolve_creds(llm_creds: dict[str, Any] | None = None) -> tuple[str, str, str]:
@@ -79,8 +94,18 @@ async def async_stream_text(
     system: str,
     llm_creds: dict[str, Any] | None = None,
     max_tokens: int = 2048,
+    log_context: dict[str, Any] | None = None,
 ) -> AsyncGenerator[str, None]:
     provider, model, api_key = _resolve_creds(llm_creds)
+    agent = _context_value(log_context, "agent")
+    trace_id = _context_value(log_context, "trace_id")
+    logger.info(
+        "LLM stream init provider=%s model=%s agent=%s trace_id=%s",
+        provider,
+        model,
+        agent,
+        trace_id,
+    )
 
     if provider == "anthropic":
         import anthropic
@@ -94,6 +119,7 @@ async def async_stream_text(
         ) as stream:
             async for text in stream.text_stream:
                 yield text
+        logger.info("LLM stream completed provider=%s agent=%s trace_id=%s", provider, agent, trace_id)
     else:
         import openai as oai
 
@@ -115,9 +141,37 @@ async def async_stream_text(
 
         stream = await client.chat.completions.create(**kwargs)
         last_content_at = time.monotonic()
+        warned_30 = False
+        warned_45 = False
+        keepalive_events = 0
         async for chunk in stream:
             if not chunk.choices:
-                if time.monotonic() - last_content_at > CONTENT_STALL_TIMEOUT_SECONDS:
+                keepalive_events += 1
+                idle_seconds = time.monotonic() - last_content_at
+                if idle_seconds >= STALL_WARNING_SECONDS[0] and not warned_30:
+                    warned_30 = True
+                    logger.warning(
+                        "Stream stall: no content for 30s (provider=%s agent=%s trace_id=%s)",
+                        provider,
+                        agent,
+                        trace_id,
+                    )
+                if idle_seconds >= STALL_WARNING_SECONDS[1] and not warned_45:
+                    warned_45 = True
+                    logger.warning(
+                        "Stream stall: no content for 45s, timeout imminent (provider=%s agent=%s trace_id=%s)",
+                        provider,
+                        agent,
+                        trace_id,
+                    )
+                if keepalive_events == 1:
+                    logger.info(
+                        "LLM keepalive chunk without content provider=%s agent=%s trace_id=%s",
+                        provider,
+                        agent,
+                        trace_id,
+                    )
+                if idle_seconds > CONTENT_STALL_TIMEOUT_SECONDS:
                     raise TimeoutError(
                         f"No content received from {provider} stream for {CONTENT_STALL_TIMEOUT_SECONDS:.0f}s"
                     )
@@ -125,7 +179,10 @@ async def async_stream_text(
             content = chunk.choices[0].delta.content or ""
             if content:
                 last_content_at = time.monotonic()
+                warned_30 = False
+                warned_45 = False
             yield content
+        logger.info("LLM stream completed provider=%s agent=%s trace_id=%s", provider, agent, trace_id)
 
 
 async def async_complete(
@@ -133,8 +190,15 @@ async def async_complete(
     system: str,
     llm_creds: dict[str, Any] | None = None,
     max_tokens: int = 2048,
+    log_context: dict[str, Any] | None = None,
 ) -> str:
     buffer = ""
-    async for chunk in async_stream_text(messages, system, llm_creds, max_tokens=max_tokens):
+    async for chunk in async_stream_text(
+        messages,
+        system,
+        llm_creds,
+        max_tokens=max_tokens,
+        log_context=log_context,
+    ):
         buffer += chunk
     return buffer

--- a/backend/tests/agents/test_architect.py
+++ b/backend/tests/agents/test_architect.py
@@ -134,3 +134,27 @@ async def test_resets_counter_on_good_line():
     all_calls = [json.loads(c.args[0]) for c in mock_ws.send_text.call_args_list]
     diagram_events = [p for p in all_calls if p.get("type") == "diagram_event"]
     assert len(diagram_events) == 4  # all 4 good nodes emitted
+
+
+@pytest.mark.asyncio
+async def test_stream_architecture_logs_edge_progress():
+    mock_ws = AsyncMock()
+
+    async def stream_with_edge(*args, **kwargs):
+        yield '{"action": "add_node", "id": "vpc", "label": "VPC", "category": "network"}\n'
+        yield '{"action": "add_edge", "from": "vpc", "to": "ecs", "label": "routes to"}\n'
+
+    with patch("agents.architect.async_stream_text", stream_with_edge):
+        with patch("agents.architect.asyncio.sleep", return_value=None):
+            from agents.architect import stream_architecture
+            await stream_architecture({}, mock_ws)
+
+    calls = [json.loads(call.args[0]) for call in mock_ws.send_text.call_args_list]
+    edge_logs = [
+        payload
+        for payload in calls
+        if payload.get("type") == "agent_log"
+        and payload.get("agent") == "architect"
+        and "Connected" in payload.get("message", "")
+    ]
+    assert len(edge_logs) == 1

--- a/backend/tests/agents/test_log_helper.py
+++ b/backend/tests/agents/test_log_helper.py
@@ -1,0 +1,37 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class MockWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_text(self, text):
+        self.sent.append(json.loads(text))
+
+
+@pytest.mark.asyncio
+async def test_emit_log_includes_structured_fields_and_trace_id():
+    from agents.log_helper import emit_log
+
+    ws = MockWebSocket()
+
+    with patch("agents.log_helper.time.time", return_value=105.0):
+        await emit_log(
+            ws,
+            "coder",
+            "Terraform ready",
+            start_time=100.0,
+            trace_id="trace-123",
+        )
+
+    assert len(ws.sent) == 1
+    payload = ws.sent[0]
+    assert payload["type"] == "agent_log"
+    assert payload["agent"] == "coder"
+    assert payload["message"] == "Terraform ready"
+    assert payload["trace_id"] == "trace-123"
+    assert payload["duration_ms"] == 5000
+    assert payload["elapsed"] == 5.0

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -206,3 +206,58 @@ def test_async_complete_times_out_when_keepalive_stream_has_no_content():
                         )
 
     asyncio.run(run())
+
+
+def test_async_complete_logs_progressive_stall_warnings_with_context():
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import pytest
+
+    class KeepAliveOnlyIterator:
+        def __init__(self):
+            self._chunks = iter(
+                [
+                    SimpleNamespace(choices=[]),
+                    SimpleNamespace(choices=[]),
+                    SimpleNamespace(choices=[]),
+                ]
+            )
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration as stop:
+                raise StopAsyncIteration from stop
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=KeepAliveOnlyIterator())
+
+    timeline = iter([0.0, 31.0, 46.0, 61.0])
+
+    def fake_monotonic():
+        return next(timeline, 61.0)
+
+    async def run():
+        with patch("llm_client._resolve_creds", return_value=("openrouter", "model-x", "sk-test")):
+            with patch("openai.AsyncOpenAI", return_value=mock_client):
+                with patch("time.monotonic", side_effect=fake_monotonic):
+                    with patch("llm_client.logger.warning") as warn:
+                        from llm_client import async_complete
+
+                        with pytest.raises(TimeoutError, match="No content"):
+                            await async_complete(
+                                messages=[{"role": "user", "content": "hello"}],
+                                system="test",
+                                log_context={"agent": "coder", "trace_id": "trace-123"},
+                            )
+
+                        warning_messages = [call.args[0] for call in warn.call_args_list if call.args]
+                        assert any("30" in message for message in warning_messages)
+                        assert any("45" in message for message in warning_messages)
+
+    asyncio.run(run())

--- a/backend/tests/test_ws_handler.py
+++ b/backend/tests/test_ws_handler.py
@@ -1072,8 +1072,8 @@ def test_chat_discovery_start_creates_new_project_when_provided_project_not_owne
 
 
 def test_discovery_chat_message_does_not_trigger_generation_before_approval(ws_client):
-    async def _mock_discovery_stream(_message, _history, _answers, llm_creds=None):
-        del llm_creds
+    async def _mock_discovery_stream(_message, _history, _answers, llm_creds=None, trace_id=None):
+        del llm_creds, trace_id
         yield "Can you share expected traffic spikes?", False
 
     auth_user = SimpleNamespace(user_id="user-123", email="user@example.com")

--- a/backend/ws_handler.py
+++ b/backend/ws_handler.py
@@ -38,9 +38,11 @@ async def _safe_send_text(websocket: WebSocket, payload: str) -> bool:
     try:
         await websocket.send_text(payload)
     except (WebSocketDisconnect, ConnectionResetError, BrokenPipeError):
+        logger.warning("ws.send_failed reason=disconnected")
         return False
     except RuntimeError as error:
         if _is_send_after_close_error(error):
+            logger.warning("ws.send_failed reason=closed_socket")
             return False
         raise
     return True
@@ -383,7 +385,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
       - canvas_edit_ack:   { type, project_id, action }
       - pipeline_event:     { type, project_id, trace_id, stage, event, level, message, ts, details? }
       - status:             { type, project_id, trace_id, message }
-      - agent_log:          { type, project_id, trace_id, agent, message, elapsed }
+      - agent_log:          { type, project_id, trace_id, agent, message, elapsed, duration_ms, details? }
       - diagram_event:      { type, project_id, trace_id, action, ... }
       - terraform_file:     { type, project_id, trace_id, filename, content, description }
       - cost_estimate:      { type, project_id, trace_id, data }
@@ -396,11 +398,15 @@ async def handle_websocket(websocket: WebSocket) -> None:
     """
 
     subscribed_projects: set[str] = set()
+    client_host = getattr(getattr(websocket, "client", None), "host", "unknown")
+    client_port = getattr(getattr(websocket, "client", None), "port", "unknown")
+    logger.info("ws.connected client=%s:%s", client_host, client_port)
 
     while True:
         try:
             raw = await websocket.receive_text()
         except WebSocketDisconnect:
+            logger.info("ws.disconnected client=%s:%s reason=websocket_disconnect", client_host, client_port)
             break
         except Exception as exc:
             logger.warning("WebSocket receive_text failed unexpectedly: %s", exc)
@@ -414,6 +420,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
             continue
 
         msg_type = data.get("type")
+        logger.info("ws.message_received type=%s client=%s:%s", msg_type, client_host, client_port)
         user_id: str | None = None
         user_email: str | None = None
 
@@ -427,6 +434,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
         }:
             token = _token_from_message(data)
             if token is None:
+                logger.warning("ws.auth_failed reason=missing_token type=%s", msg_type)
                 if not await _safe_send_json(
                     websocket,
                     {
@@ -440,6 +448,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
 
             auth_user = await verify_access_token_user(token)
             if auth_user is None:
+                logger.warning("ws.auth_failed reason=invalid_token type=%s", msg_type)
                 if not await _safe_send_json(
                     websocket,
                     {
@@ -452,6 +461,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
                 continue
             user_id = auth_user.user_id
             user_email = auth_user.email
+            logger.info("ws.auth_ok user_id=%s type=%s", user_id, msg_type)
 
         if msg_type == "start_generation":
             answers = _normalize_generation_answers(data.get("answers", {}))
@@ -642,7 +652,15 @@ async def handle_websocket(websocket: WebSocket) -> None:
             try:
                 if is_discovery_mode:
                     async for chunk, is_plan_sentinel in stream_discovery_reply(
-                        user_message, prior_history, questionnaire_answers, llm_creds=llm_creds
+                        user_message,
+                        prior_history,
+                        questionnaire_answers,
+                        llm_creds=llm_creds,
+                        trace_id=(
+                            project_row.get("generation_trace_id")
+                            if isinstance(project_row.get("generation_trace_id"), str)
+                            else None
+                        ),
                     ):
                         if is_plan_sentinel:
                             plan_ready_flag = True
@@ -1213,3 +1231,4 @@ async def handle_websocket(websocket: WebSocket) -> None:
     for project_id in list(subscribed_projects):
         await unsubscribe_websocket(project_id, websocket)
     await unsubscribe_websocket_from_all(websocket)
+    logger.info("ws.cleanup_complete client=%s:%s", client_host, client_port)

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -365,7 +365,13 @@ The backend emits `agent_log` messages in real-time as each agent makes progress
   "type": "agent_log",
   "agent": "architect",
   "message": "Added ECS Fargate (compute)",
-  "elapsed": 4.2
+  "elapsed": 4.2,
+  "duration_ms": 4200,
+  "trace_id": "uuid",
+  "details": {
+    "nodes": 4,
+    "edges": 3
+  }
 }
 ```
 
@@ -373,6 +379,9 @@ The backend emits `agent_log` messages in real-time as each agent makes progress
 - `agent`: one of `"requirements"` | `"architect"` | `"coder"` | `"cost_analyst"` | `"description"`
 - `message`: human-readable progress string (e.g. `"Generating Terraform..."`, `"Writing main.tf"`)
 - `elapsed`: seconds since the pipeline `start_time` (rounded to 1 decimal)
+- `duration_ms`: elapsed milliseconds since the pipeline `start_time`
+- `trace_id`: generation correlation ID (nullable during discovery or standalone tests)
+- `details`: optional agent-specific metadata object
 
 **TypeScript type:**
 ```typescript
@@ -381,6 +390,9 @@ type AgentLogEntry = {
   agent: "requirements" | "architect" | "coder" | "cost_analyst" | "description";
   message: string;
   elapsed: number;
+  duration_ms?: number;
+  trace_id?: string | null;
+  details?: Record<string, unknown>;
 };
 ```
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -122,6 +122,7 @@ A single-screen form that replaces the old multi-step questionnaire. Two submiss
 | `project_ready` | `{ project_id, share_slug }` | New project created; frontend should update URL |
 | `generation_snapshot` | `{ project_id, project_mode, generation_status, generation_stage, generation_error, generation_trace_id, generation_started_at, generation_completed_at, last_event_at }` | Snapshot for subscribe/reconnect, including persisted discovery/default mode |
 | `diagram_event` | `{ action: "add_node"\|"add_edge", id, label, category, project_id, trace_id }` | Live canvas update; consumed incrementally |
+| `agent_log` | `{ agent, message, elapsed, duration_ms, trace_id?, details?, project_id? }` | Agent lifecycle/progress breadcrumb shown in activity feed and correlated backend logs |
 | `chat_reply` | `{ message, project_id, plan_ready?: bool }` | Assistant message; `plan_ready: true` triggers "Accept & Generate" button |
 | `chat_reply_delta` | `{ delta, project_id }` | Streaming chunk for assistant message |
 | `chat_reply_done` | `{ message, project_id, plan_ready?: bool }` | Final assembled message after streaming |


### PR DESCRIPTION
## Summary
- add structured agent observability logging (trace-aware `agent_log` payloads with `duration_ms` and optional `details`) across requirements, discovery, architect, coder, cost analyst, and description
- add LLM client stream observability (provider/model stream init, keepalive visibility, and progressive stall warnings at 30s/45s before the 60s timeout)
- add backend WebSocket observability (connect/disconnect, message type receipt, auth outcome, and send-failure logs), plus docs updates for the `agent_log` contract

## Test Plan
- [x] `cd backend && uv run pytest`

Closes #87