### PR TITLE
feat(auth): add Google OAuth login

### DIFF
--- a/frontend/components/auth/AuthProvider.tsx
+++ b/frontend/components/auth/AuthProvider.tsx
@@ -13,7 +13,7 @@ import type { AuthError, Session, User } from "@supabase/supabase-js";
 import { getSupabaseBrowserClient } from "@/lib/supabase/browser";
 import { isAppDomainHost, isAuthRoute, isPublicShareRoute } from "@/lib/domains";
 
-export type OAuthProvider = "github" | "google";
+export type OAuthProvider = "google";
 
 interface AuthContextValue {
   user: User | null;

--- a/frontend/components/auth/OAuthButtons.tsx
+++ b/frontend/components/auth/OAuthButtons.tsx
@@ -1,30 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth, type OAuthProvider } from "@/components/auth/AuthProvider";
+import { useAuth } from "@/components/auth/AuthProvider";
 
 interface Props {
   onError: (message: string | null) => void;
 }
 
-const providers: Array<{ key: OAuthProvider; label: string }> = [
-  { key: "github", label: "Continue with GitHub" },
-  { key: "google", label: "Continue with Google" },
-];
-
 export default function OAuthButtons({ onError }: Props) {
   const { signInWithOAuth } = useAuth();
-  const [loadingProvider, setLoadingProvider] = useState<OAuthProvider | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  if (process.env.NEXT_PUBLIC_ENABLE_SOCIAL_AUTH !== "true") {
-    return null;
-  }
-
-  async function handleOAuth(provider: OAuthProvider) {
+  async function handleGoogle() {
     onError(null);
-    setLoadingProvider(provider);
-    const error = await signInWithOAuth(provider);
-    setLoadingProvider(null);
+    setLoading(true);
+    const error = await signInWithOAuth("google");
+    setLoading(false);
 
     if (error) {
       onError(error.message);
@@ -32,18 +23,31 @@ export default function OAuthButtons({ onError }: Props) {
   }
 
   return (
-    <div className="space-y-2">
-      {providers.map((provider) => (
-        <button
-          key={provider.key}
-          type="button"
-          onClick={() => void handleOAuth(provider.key)}
-          disabled={loadingProvider !== null}
-          className="w-full rounded-[10px] border border-gray-700 bg-gray-800 px-[18px] py-[12px] text-sm text-gray-100 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          {loadingProvider === provider.key ? "Redirecting..." : provider.label}
-        </button>
-      ))}
-    </div>
+    <button
+      type="button"
+      onClick={() => void handleGoogle()}
+      disabled={loading}
+      className="w-full flex items-center justify-center gap-3 rounded-[10px] border border-gray-700 bg-gray-800 px-[18px] py-[12px] text-sm text-gray-100 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+    >
+      <svg className="h-5 w-5" viewBox="0 0 24 24">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+      {loading ? "Redirecting..." : "Continue with Google"}
+    </button>
   );
 }

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -23,5 +23,8 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
   }
 }


### PR DESCRIPTION
## Summary
- Enable Google sign-in button on login and register pages (removes `NEXT_PUBLIC_ENABLE_SOCIAL_AUTH` env var gate)
- Simplify `OAuthButtons` to Google-only with branded SVG logo
- Fix nginx 502 on OAuth callback by increasing proxy buffer sizes for large Supabase auth cookies

Closes #89

## Test plan
- [ ] Click "Continue with Google" on `/login` — redirects to Google consent screen
- [ ] After Google consent, callback redirects to `/` with active session
- [ ] Click "Continue with Google" on `/register` — same flow, creates new user
- [ ] Email/password login still works alongside Google

🤖 Generated with [Claude Code](https://claude.com/claude-code)