### PR TITLE
Fix issue #101: templates right panel and in-place loading

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from project_store import (
     clone_template_project_for_user,
     create_project_for_generation,
     get_project_for_user,
+    get_template_project_detail,
     list_template_projects,
     reset_stale_generations,
     update_project_fields,
@@ -198,6 +199,18 @@ class TemplateSummaryResponse(BaseModel):
     title: str
     share_slug: str
     thumbnail_url: str | None = None
+    description: str | None = None
+
+
+class TemplateDetailResponse(BaseModel):
+    title: str
+    share_slug: str
+    thumbnail_url: str | None = None
+    nodes: list[dict[str, Any]]
+    edges: list[dict[str, Any]]
+    terraform_files: list[dict[str, Any]]
+    cost_estimate: dict[str, Any] | None = None
+    arch_description: dict[str, Any] | None = None
 
 
 class CloneTemplateRequest(BaseModel):
@@ -497,6 +510,25 @@ async def list_templates_endpoint():
         raise HTTPException(
             status_code=500,
             detail={"error": "templates_fetch_failed", "message": "Unable to load templates right now."},
+        ) from error
+
+
+@app.get(
+    "/api/templates/{slug}",
+    summary="Get template detail",
+    description="Returns full template snapshot data for in-place canvas loading.",
+    response_model=TemplateDetailResponse,
+    tags=["templates"],
+)
+async def template_detail_endpoint(slug: str):
+    try:
+        return await get_template_project_detail(slug)
+    except TemplateNotFoundError as error:
+        raise HTTPException(status_code=404, detail={"error": "template_not_found", "message": str(error)}) from error
+    except Exception as error:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "template_fetch_failed", "message": "Unable to load template right now."},
         ) from error
 
 

--- a/backend/project_store.py
+++ b/backend/project_store.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import string
 import secrets
@@ -256,7 +257,7 @@ async def append_chat_message(project_id: str, user_id: str, message: dict[str, 
 def _list_template_projects_sync() -> list[dict[str, Any]]:
     response = (
         supabase.table("projects")
-        .select("title, share_slug, thumbnail_url")
+        .select("title, share_slug, thumbnail_url, description")
         .eq("is_template", True)
         .order("updated_at", desc=True)
         .execute()
@@ -276,11 +277,20 @@ def _list_template_projects_sync() -> list[dict[str, Any]]:
             continue
 
         thumbnail_url = row.get("thumbnail_url") if isinstance(row.get("thumbnail_url"), str) else None
+        raw_description = row.get("description")
+        description: str | None = None
+        if isinstance(raw_description, str) and raw_description.strip():
+            description = raw_description.strip()
+        elif isinstance(raw_description, dict):
+            overview = raw_description.get("overview")
+            if isinstance(overview, str) and overview.strip():
+                description = overview.strip()
         templates.append(
             {
                 "title": title.strip(),
                 "share_slug": slug.strip(),
                 "thumbnail_url": thumbnail_url,
+                "description": description,
             }
         )
 
@@ -289,6 +299,52 @@ def _list_template_projects_sync() -> list[dict[str, Any]]:
 
 async def list_template_projects() -> list[dict[str, Any]]:
     return await asyncio.to_thread(_list_template_projects_sync)
+
+
+def _get_template_project_detail_sync(template_slug: str) -> dict[str, Any]:
+    response = (
+        supabase.table("projects")
+        .select(
+            "title, share_slug, thumbnail_url, nodes, edges, terraform_files, "
+            "cost_estimate, description"
+        )
+        .eq("is_template", True)
+        .eq("share_slug", template_slug)
+        .single()
+        .execute()
+    )
+    data = getattr(response, "data", None)
+    if not isinstance(data, dict):
+        raise TemplateNotFoundError("Template not found.")
+
+    title = data.get("title") if isinstance(data.get("title"), str) else "Untitled Template"
+    share_slug = data.get("share_slug") if isinstance(data.get("share_slug"), str) else template_slug
+    raw_description = data.get("description")
+    if isinstance(raw_description, dict):
+        arch_description = raw_description
+    elif isinstance(raw_description, str):
+        try:
+            parsed_description = json.loads(raw_description)
+            arch_description = parsed_description if isinstance(parsed_description, dict) else None
+        except json.JSONDecodeError:
+            arch_description = None
+    else:
+        arch_description = None
+
+    return {
+        "title": title,
+        "share_slug": share_slug,
+        "thumbnail_url": data.get("thumbnail_url") if isinstance(data.get("thumbnail_url"), str) else None,
+        "nodes": data.get("nodes") if isinstance(data.get("nodes"), list) else [],
+        "edges": data.get("edges") if isinstance(data.get("edges"), list) else [],
+        "terraform_files": data.get("terraform_files") if isinstance(data.get("terraform_files"), list) else [],
+        "cost_estimate": data.get("cost_estimate"),
+        "arch_description": arch_description,
+    }
+
+
+async def get_template_project_detail(template_slug: str) -> dict[str, Any]:
+    return await asyncio.to_thread(_get_template_project_detail_sync, template_slug)
 
 
 def _clone_template_project_for_user_sync(template_slug: str, user_id: str) -> dict[str, Any]:

--- a/backend/tests/test_templates_endpoint.py
+++ b/backend/tests/test_templates_endpoint.py
@@ -4,8 +4,18 @@ from unittest.mock import AsyncMock, patch
 
 def test_get_templates_returns_public_template_metadata(client):
     templates = [
-        {"title": "ECS + RDS", "share_slug": "tmpl0001", "thumbnail_url": "https://cdn.example/t1.png"},
-        {"title": "Lambda + API Gateway", "share_slug": "tmpl0002", "thumbnail_url": None},
+        {
+            "title": "ECS + RDS",
+            "share_slug": "tmpl0001",
+            "thumbnail_url": "https://cdn.example/t1.png",
+            "description": "Scale-ready web app with managed DB",
+        },
+        {
+            "title": "Lambda + API Gateway",
+            "share_slug": "tmpl0002",
+            "thumbnail_url": None,
+            "description": "Event-driven serverless architecture",
+        },
     ]
 
     with patch("main.list_template_projects", new=AsyncMock(return_value=templates), create=True):
@@ -13,6 +23,39 @@ def test_get_templates_returns_public_template_metadata(client):
 
     assert response.status_code == 200
     assert response.json() == templates
+
+
+def test_get_template_detail_returns_full_snapshot(client):
+    detail = {
+        "title": "ECS + RDS",
+        "share_slug": "tmpl0001",
+        "thumbnail_url": "https://cdn.example/t1.png",
+        "nodes": [{"id": "vpc"}],
+        "edges": [{"id": "vpc-rds"}],
+        "terraform_files": [{"filename": "main.tf", "content": "resource {}"}],
+        "cost_estimate": {"monthly_total": 42.0, "breakdown": []},
+        "arch_description": {"overview": "Sample"},
+    }
+
+    with patch("main.get_template_project_detail", new=AsyncMock(return_value=detail), create=True):
+        response = client.get("/api/templates/tmpl0001")
+
+    assert response.status_code == 200
+    assert response.json() == detail
+
+
+def test_get_template_detail_returns_not_found(client):
+    from main import TemplateNotFoundError
+
+    with patch(
+        "main.get_template_project_detail",
+        new=AsyncMock(side_effect=TemplateNotFoundError("Template not found.")),
+        create=True,
+    ):
+        response = client.get("/api/templates/missing")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"] == "template_not_found"
 
 
 def test_clone_template_requires_token(client):

--- a/docs/superpowers/plans/2026-03-24-templates-right-panel.md
+++ b/docs/superpowers/plans/2026-03-24-templates-right-panel.md
@@ -1,0 +1,95 @@
+# Templates Right Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move template browsing/loading into the right panel and load template content in-place on the canvas.
+
+**Architecture:** Add a public backend endpoint for full template detail by slug, extend frontend template API utilities, and wire a new `templates` right-panel tab that fetches list/detail and applies detail through a dedicated canvas pipeline snapshot loader. Keep clone flow unchanged.
+
+**Tech Stack:** FastAPI, Supabase Python client, Next.js 14, React, TypeScript, React Flow, Vitest, pytest
+
+---
+
+### Task 1: Backend template detail endpoint
+
+**Files:**
+- Modify: `backend/tests/test_templates_endpoint.py`
+- Modify: `backend/project_store.py`
+- Modify: `backend/main.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+Add tests for:
+- success response from `GET /api/templates/{slug}`
+- 404 `template_not_found` response
+
+- [ ] **Step 2: Run backend template endpoint tests (expect fail)**
+Run: `cd backend && uv run pytest tests/test_templates_endpoint.py -v`
+
+- [ ] **Step 3: Implement store helper + endpoint**
+Add project-store helper to fetch full template snapshot and expose `GET /api/templates/{slug}` in `main.py` with documented FastAPI metadata.
+
+- [ ] **Step 4: Re-run backend tests (expect pass)**
+Run: `cd backend && uv run pytest tests/test_templates_endpoint.py -v`
+
+---
+
+### Task 2: Frontend template detail API client
+
+**Files:**
+- Modify: `frontend/lib/__tests__/templates.test.ts`
+- Modify: `frontend/lib/templates.ts`
+
+- [ ] **Step 1: Write failing parser tests**
+Add tests for template detail payload parsing validity and invalid payload rejection.
+
+- [ ] **Step 2: Run frontend template tests (expect fail)**
+Run: `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
+
+- [ ] **Step 3: Implement detail types/parser/fetcher**
+Add `TemplateDetail`, `parseTemplateDetailResponse`, and `fetchTemplateDetail(slug)`.
+
+- [ ] **Step 4: Re-run frontend template tests (expect pass)**
+Run: `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
+
+---
+
+### Task 3: Right panel templates UI + in-place load orchestration
+
+**Files:**
+- Modify: `frontend/lib/useWorkspace.ts`
+- Modify: `frontend/lib/useCanvasPipeline.ts`
+- Create: `frontend/components/RightPanel/TemplateCard.tsx`
+- Create: `frontend/components/RightPanel/TemplatesPanel.tsx`
+- Modify: `frontend/components/RightPanel.tsx`
+- Modify: `frontend/app/page.tsx`
+
+- [ ] **Step 1: Add workspace/pipeline extension points**
+- `RightPanelTab` includes `templates`
+- add `openTemplates()` in workspace hook
+- add `loadTemplateSnapshot(data)` in canvas pipeline
+
+- [ ] **Step 2: Add templates panel components**
+Render list/error/empty/loading states and per-card “Use” action.
+
+- [ ] **Step 3: Wire right panel and page handlers**
+- TopBar templates button opens templates tab
+- pass `onUseTemplate` into right panel
+- `handleUseTemplate` confirms discard when needed, fetches detail, and applies snapshot
+
+- [ ] **Step 4: Run focused frontend validation**
+Run: `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
+
+---
+
+### Task 4: End-to-end verification commands
+
+**Files:** none
+
+- [ ] **Step 1: Backend test verification**
+Run: `cd backend && uv run pytest tests/test_templates_endpoint.py -v`
+
+- [ ] **Step 2: Frontend test verification**
+Run: `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
+
+- [ ] **Step 3: Final workspace check**
+Run: `git status --short`

--- a/docs/superpowers/specs/2026-03-24-templates-right-panel-design.md
+++ b/docs/superpowers/specs/2026-03-24-templates-right-panel-design.md
@@ -13,6 +13,8 @@ Move template browsing into the collapsible right panel. Users click "Templates"
 
 Returns full template data for a single template. Public (no auth required).
 
+> **Note:** The existing `POST /api/templates/{slug}/clone` endpoint remains unchanged — it is used for clone-based flows (e.g., future use cases). The new GET endpoint serves a different purpose: fetching template data for in-place canvas loading without creating a new project. The frontend `cloneTemplate()` function and `CloneTemplateResponse` type in `templates.ts` are kept as-is (not dead code — they may be used by other flows).
+
 **Response shape:**
 
 ```json
@@ -28,10 +30,12 @@ Returns full template data for a single template. Public (no auth required).
 }
 ```
 
+> **Auth note:** This endpoint is intentionally public. Templates are curated showcase content, not user-private data. The existing `GET /api/templates` list endpoint is also public. The clone endpoint remains auth-gated because it creates a user-owned project and consumes quota.
+
 **Error responses:**
 - `404` — template not found
 
-**Implementation:** Query Supabase for projects where `is_template = True` and `share_slug = {slug}`. Return full project data. Reuse existing `project_store` helpers.
+**Implementation:** Query Supabase for projects where `is_template = True` and `share_slug = {slug}`. Return full project data including nodes, edges, terraform_files, cost_estimate, and `description` (mapped to `arch_description` in the response, matching the field name the frontend expects). Reuse existing `project_store` helpers.
 
 ## Frontend
 
@@ -42,13 +46,29 @@ Add `"templates"` to the `RightPanelTab` union type in `useWorkspace.ts`.
 ### `useWorkspace.ts` changes
 
 - New function `openTemplates()`: sets `rightPanelTab = "templates"`, `rightPanelOpen = true`
-- New function `loadTemplate(slug: string)`:
-  1. If canvas has nodes → show confirmation dialog (return early if cancelled)
-  2. Call `fetchTemplateDetail(slug)`
-  3. Call `hydrate(nodes, edges)` on diagram state
-  4. Set terraform files, cost estimate, arch description from response
-  5. If active project: keep project context, update local state
-  6. If no project: enter "unsaved design" state with template content
+- Add `"templates"` to the `RightPanelTab` union type
+
+### `useCanvasPipeline.ts` changes
+
+New function `loadTemplateSnapshot(data: TemplateDetail)`:
+  1. Call `hydrate(data.nodes, data.edges)` (already available from `useDiagramState`)
+  2. Call `setTerraformFiles(data.terraform_files)` (internal setter, already in scope)
+  3. Call `setCostEstimate(data.cost_estimate)` (internal setter, already in scope)
+  4. Call `setArchDescription(data.arch_description)` (internal setter, already in scope)
+  5. Call `applyLayout()` if node positions are invalid
+
+Expose `loadTemplateSnapshot` in the return object so `page.tsx` can call `pipeline.loadTemplateSnapshot(data)`.
+
+> **Why here and not in `useWorkspace`:** The `hydrate`, `setTerraformFiles`, `setCostEstimate`, and `setArchDescription` functions are all internal to `useCanvasPipeline`. Rather than exposing individual setters, we add one atomic "load snapshot" function.
+
+### Template loading orchestration (in `page.tsx`)
+
+The `loadTemplate(slug)` handler lives in `page.tsx` (where both `workspace` and `pipeline` are accessible):
+  1. If `pipeline.nodes.length > 0` → show confirmation dialog (return early if cancelled)
+  2. Call `fetchTemplateDetail(slug)` → get full template data
+  3. Call `pipeline.loadTemplateSnapshot(data)` → hydrate canvas + set outputs
+  4. If active project (`workspace.currentProject`): keep project context, state is now updated locally
+  5. If no project: the canvas simply shows template content without a project association. This is the same visual state as when a user has nodes on canvas but hasn't saved yet. No new "unsaved design" concept is needed — the pipeline renders whatever nodes/edges are in its state regardless of whether a `currentProject` exists.
 
 ### `frontend/lib/templates.ts` additions
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import LeftPanel from "@/components/LeftPanel";
 import RightPanel from "@/components/RightPanel";
 import TopBar from "@/components/TopBar";
 import { useProjectDelete } from "@/lib/projectActions";
+import { fetchTemplateDetail } from "@/lib/templates";
 import { useWorkspace } from "@/lib/useWorkspace";
 
 function WorkspaceContent() {
@@ -50,7 +51,24 @@ function WorkspaceContent() {
   }
 
   function handleTemplates() {
-    toast.message("Templates are coming in a follow-up issue.");
+    workspace.openTemplates();
+  }
+
+  async function handleUseTemplate(slug: string) {
+    if (pipeline.nodes.length > 0) {
+      const shouldReplace = window.confirm(
+        "Discard current design? Loading this template will replace your current canvas."
+      );
+      if (!shouldReplace) return;
+    }
+
+    try {
+      const template = await fetchTemplateDetail(slug);
+      pipeline.loadTemplateSnapshot(template);
+      toast.success(`Loaded template: ${template.title}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to load template");
+    }
   }
 
   function handleAutoLayout() {
@@ -163,6 +181,7 @@ function WorkspaceContent() {
           projectsLoading={workspace.projectsLoading}
           onOpenProject={handleOpenProject}
           onDeleteProject={projectDelete.handleDeleteClick}
+          onUseTemplate={handleUseTemplate}
           pendingDeleteId={projectDelete.pendingDeleteId}
           isDeleting={projectDelete.isDeleting}
           onConfirmDelete={projectDelete.confirmDelete}

--- a/frontend/components/RightPanel.tsx
+++ b/frontend/components/RightPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { X } from "lucide-react";
+import { LayoutGrid, X } from "lucide-react";
 import OutputPanel, { type CostEstimate, type TerraformFile } from "@/components/OutputPanel";
 import type { ArchDescription } from "@/components/ArchDescriptionViewer";
 import MyDesignsList from "@/components/RightPanel/MyDesignsList";
+import TemplatesPanel from "@/components/RightPanel/TemplatesPanel";
 import type { ProjectSummary } from "@/lib/projects";
 import type { SetupPdfState } from "@/lib/setupPdf";
 import type { TerraformProgress } from "@/components/TerraformViewer";
@@ -28,6 +29,7 @@ interface RightPanelProps {
   projectsLoading: boolean;
   onOpenProject: (slug: string) => void;
   onDeleteProject: (id: string) => void;
+  onUseTemplate: (slug: string) => void;
   pendingDeleteId: string | null;
   isDeleting: boolean;
   onConfirmDelete: () => Promise<void>;
@@ -51,12 +53,14 @@ export default function RightPanel({
   projectsLoading,
   onOpenProject,
   onDeleteProject,
+  onUseTemplate,
   pendingDeleteId,
   isDeleting,
   onConfirmDelete,
   onCancelDelete,
 }: RightPanelProps) {
-  const tabTitle = tab === "output" ? "Output" : "My Designs";
+  const tabTitle = tab === "output" ? "Output" : tab === "designs" ? "My Designs" : "Templates";
+  const isTemplatesTab = tab === "templates";
 
   return (
     <div
@@ -65,12 +69,15 @@ export default function RightPanel({
       }`}
       style={{ marginRight: open ? 0 : "-20rem" }}
     >
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
-        <h2 className="text-sm font-semibold text-white">{tabTitle}</h2>
+      <div className={`flex items-center justify-between px-4 py-4 border-b ${isTemplatesTab ? "border-[#1b2339] bg-[#0b1020]" : "border-gray-800"}`}>
+        <h2 className={`flex items-center gap-2 text-sm ${isTemplatesTab ? "font-semibold tracking-[0.02em] text-[#e4ebff]" : "font-semibold text-white"}`}>
+          {isTemplatesTab && <LayoutGrid size={15} className="text-blue-500" />}
+          {tabTitle}
+        </h2>
         <button
           type="button"
           onClick={onClose}
-          className="p-1 rounded text-gray-400 hover:text-white hover:bg-gray-800 transition-colors"
+          className={`p-1 rounded transition-colors ${isTemplatesTab ? "text-[#6e7aa5] hover:text-[#c6d4ff] hover:bg-[#131a30]" : "text-gray-400 hover:text-white hover:bg-gray-800"}`}
           aria-label="Close right panel"
         >
           <X size={16} />
@@ -90,7 +97,7 @@ export default function RightPanel({
             onGenerateSetupPdf={onGenerateSetupPdf}
             onDownloadSetupPdf={onDownloadSetupPdf}
           />
-        ) : (
+        ) : tab === "designs" ? (
           <MyDesignsList
             projects={projects}
             loading={projectsLoading}
@@ -101,6 +108,8 @@ export default function RightPanel({
             onConfirmDelete={onConfirmDelete}
             onCancelDelete={onCancelDelete}
           />
+        ) : (
+          <TemplatesPanel onUseTemplate={onUseTemplate} />
         )}
       </div>
     </div>

--- a/frontend/components/RightPanel/TemplateCard.tsx
+++ b/frontend/components/RightPanel/TemplateCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { ArrowRight, Bot, Link2, ShieldCheck, Workflow } from "lucide-react";
+import type { TemplateSummary } from "@/lib/templates";
+
+type TemplateCardProps = {
+  template: TemplateSummary;
+  onUse: (slug: string) => void;
+};
+
+function iconForTemplate(title: string) {
+  const value = title.toLowerCase();
+  if (value.includes("url") || value.includes("shortener")) return Link2;
+  if (value.includes("agent") || value.includes("llm")) return Bot;
+  if (value.includes("secure") || value.includes("bank") || value.includes("ledger")) return ShieldCheck;
+  return Workflow;
+}
+
+export default function TemplateCard({ template, onUse }: TemplateCardProps) {
+  const Icon = iconForTemplate(template.title);
+  return (
+    <article className="h-[196px] rounded-3xl border border-[#21273a] bg-[#151a2c]/75 px-5 py-4 hover:border-[#2e3a5d] transition-colors flex flex-col">
+      <div className="flex items-center gap-2.5">
+        <Icon size={15} className="text-blue-500 shrink-0" />
+        <h3 className="text-[19px] font-semibold tracking-[0.01em] text-gray-100 leading-tight" title={template.title}>
+          {template.title}
+        </h3>
+      </div>
+
+      <p className="mt-3 text-[14px] leading-5 text-[#7f8aa7] h-[72px] overflow-hidden">
+        {template.description ?? "Production-ready architecture blueprint with resilient and scalable AWS primitives."}
+      </p>
+
+      <div className="mt-auto flex justify-end">
+        <button
+          type="button"
+          onClick={() => onUse(template.share_slug)}
+          className="inline-flex items-center gap-1 text-[13px] font-semibold uppercase tracking-[0.14em] text-blue-500 hover:text-blue-400 transition-colors"
+        >
+          Load
+          <ArrowRight size={13} />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/RightPanel/TemplatesPanel.tsx
+++ b/frontend/components/RightPanel/TemplatesPanel.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import TemplateCard from "@/components/RightPanel/TemplateCard";
+import { useTemplatesPanel } from "@/components/RightPanel/useTemplatesPanel";
+
+type TemplatesPanelProps = {
+  onUseTemplate: (slug: string) => void;
+};
+
+export default function TemplatesPanel({ onUseTemplate }: TemplatesPanelProps) {
+  const { templates, loading, error, reload } = useTemplatesPanel();
+
+  if (loading) {
+    return (
+      <div className="flex-1 overflow-y-auto px-4 py-5 space-y-4 bg-[linear-gradient(180deg,#0b1020_0%,#0a0f1c_100%)]">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-[196px] rounded-3xl border border-[#21273a] bg-[#151a2c]/75 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center px-6 text-center bg-[linear-gradient(180deg,#0b1020_0%,#0a0f1c_100%)]">
+        <p className="text-sm text-red-300">Failed to load templates</p>
+        <p className="text-xs text-gray-400 mt-1">{error}</p>
+        <button
+          type="button"
+          onClick={() => void reload()}
+          className="mt-3 px-3 py-1 text-xs rounded border border-gray-600 text-gray-300 hover:bg-gray-800 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (templates.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-6 bg-[linear-gradient(180deg,#0b1020_0%,#0a0f1c_100%)]">
+        <p className="text-sm text-gray-400">No templates available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-5 flex flex-col gap-4 bg-[linear-gradient(180deg,#0b1020_0%,#0a0f1c_100%)]">
+      {templates.map((template) => (
+        <TemplateCard
+          key={template.share_slug}
+          template={template}
+          onUse={onUseTemplate}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/RightPanel/useTemplatesPanel.ts
+++ b/frontend/components/RightPanel/useTemplatesPanel.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchTemplates, type TemplateSummary } from "@/lib/templates";
+
+type TemplatesPanelState = {
+  templates: TemplateSummary[];
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+};
+
+export function useTemplatesPanel(): TemplatesPanelState {
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchTemplates();
+      setTemplates(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load templates");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { templates, loading, error, reload };
+}

--- a/frontend/lib/__tests__/templates.test.ts
+++ b/frontend/lib/__tests__/templates.test.ts
@@ -1,27 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { parseCloneTemplateResponse, parseTemplatesResponse } from "../templates";
+import { parseCloneTemplateResponse, parseTemplateDetailResponse, parseTemplatesResponse } from "../templates";
 
 describe("template API response parsers", () => {
   it("parses valid template list payload", () => {
     const parsed = parseTemplatesResponse([
-      { title: "ECS + RDS", share_slug: "tmpl0001", thumbnail_url: "https://cdn.example/t1.png" },
-      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null },
+      {
+        title: "ECS + RDS",
+        share_slug: "tmpl0001",
+        thumbnail_url: "https://cdn.example/t1.png",
+        description: "Scale-ready web app with managed DB",
+      },
+      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null, description: "Serverless API and jobs" },
     ]);
 
     expect(parsed).toEqual([
-      { title: "ECS + RDS", share_slug: "tmpl0001", thumbnail_url: "https://cdn.example/t1.png" },
-      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null },
+      {
+        title: "ECS + RDS",
+        share_slug: "tmpl0001",
+        thumbnail_url: "https://cdn.example/t1.png",
+        description: "Scale-ready web app with managed DB",
+      },
+      { title: "Lambda", share_slug: "tmpl0002", thumbnail_url: null, description: "Serverless API and jobs" },
     ]);
   });
 
   it("filters malformed template rows", () => {
     const parsed = parseTemplatesResponse([
-      { title: "Valid", share_slug: "tmpl0001", thumbnail_url: null },
+      { title: "Valid", share_slug: "tmpl0001", thumbnail_url: null, description: "Valid row" },
       { title: "Missing slug" },
       "invalid",
     ]);
 
-    expect(parsed).toEqual([{ title: "Valid", share_slug: "tmpl0001", thumbnail_url: null }]);
+    expect(parsed).toEqual([{ title: "Valid", share_slug: "tmpl0001", thumbnail_url: null, description: "Valid row" }]);
   });
 
   it("parses valid clone response", () => {
@@ -31,5 +41,34 @@ describe("template API response parsers", () => {
   it("returns null for invalid clone response", () => {
     expect(parseCloneTemplateResponse({})).toBeNull();
     expect(parseCloneTemplateResponse("nope")).toBeNull();
+  });
+
+  it("parses valid template detail response", () => {
+    const parsed = parseTemplateDetailResponse({
+      title: "ECS + RDS",
+      share_slug: "tmpl0001",
+      thumbnail_url: "https://cdn.example/t1.png",
+      nodes: [{ id: "vpc", type: "service", position: { x: 0, y: 0 }, data: { label: "VPC", category: "network" } }],
+      edges: [{ id: "e1", source: "vpc", target: "alb" }],
+      terraform_files: [{ filename: "main.tf", content: "resource {}" }],
+      cost_estimate: { monthly_total: 42, breakdown: [] },
+      arch_description: { overview: "Sample architecture" },
+    });
+
+    expect(parsed).toEqual({
+      title: "ECS + RDS",
+      share_slug: "tmpl0001",
+      thumbnail_url: "https://cdn.example/t1.png",
+      nodes: [{ id: "vpc", type: "service", position: { x: 0, y: 0 }, data: { label: "VPC", category: "network" } }],
+      edges: [{ id: "e1", source: "vpc", target: "alb" }],
+      terraform_files: [{ filename: "main.tf", content: "resource {}", description: "" }],
+      cost_estimate: { monthly_total: 42, breakdown: [] },
+      arch_description: { overview: "Sample architecture" },
+    });
+  });
+
+  it("returns null for invalid template detail response", () => {
+    expect(parseTemplateDetailResponse({ title: "Missing slug" })).toBeNull();
+    expect(parseTemplateDetailResponse({ title: "X", share_slug: "s", nodes: "bad" })).toBeNull();
   });
 });

--- a/frontend/lib/templates.ts
+++ b/frontend/lib/templates.ts
@@ -1,13 +1,27 @@
 import { withAccessToken } from "./generationStart";
+import type { ArchDescription, CostEstimate, TerraformFile } from "@/components/OutputPanel";
+import type { Edge, Node } from "reactflow";
 
 export type TemplateSummary = {
   title: string;
   share_slug: string;
   thumbnail_url: string | null;
+  description: string | null;
 };
 
 export type CloneTemplateResponse = {
   share_slug: string;
+};
+
+export type TemplateDetail = {
+  title: string;
+  share_slug: string;
+  thumbnail_url: string | null;
+  nodes: Node[];
+  edges: Edge[];
+  terraform_files: TerraformFile[];
+  cost_estimate: CostEstimate | null;
+  arch_description: ArchDescription | null;
 };
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -37,7 +51,10 @@ export function parseTemplatesResponse(body: unknown): TemplateSummary[] {
       const thumbnail_url = typeof item.thumbnail_url === "string" && item.thumbnail_url.trim()
         ? item.thumbnail_url
         : null;
-      return [{ title: item.title.trim(), share_slug: item.share_slug.trim(), thumbnail_url }];
+      const description = typeof item.description === "string" && item.description.trim()
+        ? item.description.trim()
+        : null;
+      return [{ title: item.title.trim(), share_slug: item.share_slug.trim(), thumbnail_url, description }];
     });
 }
 
@@ -45,6 +62,37 @@ export function parseCloneTemplateResponse(body: unknown): CloneTemplateResponse
   if (!isRecord(body)) return null;
   if (typeof body.share_slug !== "string" || !body.share_slug.trim()) return null;
   return { share_slug: body.share_slug.trim() };
+}
+
+export function parseTemplateDetailResponse(body: unknown): TemplateDetail | null {
+  if (!isRecord(body)) return null;
+  if (typeof body.title !== "string" || !body.title.trim()) return null;
+  if (typeof body.share_slug !== "string" || !body.share_slug.trim()) return null;
+  if (!Array.isArray(body.nodes) || !Array.isArray(body.edges) || !Array.isArray(body.terraform_files)) return null;
+
+  const thumbnail_url = typeof body.thumbnail_url === "string" && body.thumbnail_url.trim()
+    ? body.thumbnail_url.trim()
+    : null;
+
+  const terraform_files = body.terraform_files
+    .filter(isRecord)
+    .flatMap((entry) => {
+      if (typeof entry.filename !== "string" || !entry.filename.trim()) return [];
+      if (typeof entry.content !== "string") return [];
+      const description = typeof entry.description === "string" ? entry.description : "";
+      return [{ filename: entry.filename.trim(), content: entry.content, description }];
+    });
+
+  return {
+    title: body.title.trim(),
+    share_slug: body.share_slug.trim(),
+    thumbnail_url,
+    nodes: body.nodes.filter(isRecord) as unknown as Node[],
+    edges: body.edges.filter(isRecord) as unknown as Edge[],
+    terraform_files,
+    cost_estimate: isRecord(body.cost_estimate) ? (body.cost_estimate as CostEstimate) : null,
+    arch_description: isRecord(body.arch_description) ? (body.arch_description as ArchDescription) : null,
+  };
 }
 
 export async function fetchTemplates(): Promise<TemplateSummary[]> {
@@ -55,6 +103,22 @@ export async function fetchTemplates(): Promise<TemplateSummary[]> {
     throw new Error(parseErrorMessage(body));
   }
   return parseTemplatesResponse(body);
+}
+
+export async function fetchTemplateDetail(slug: string): Promise<TemplateDetail> {
+  const response = await fetch(`${API_URL}/api/templates/${encodeURIComponent(slug)}`);
+  const body = (await response.json().catch(() => ({}))) as unknown;
+
+  if (!response.ok) {
+    throw new Error(parseErrorMessage(body));
+  }
+
+  const parsed = parseTemplateDetailResponse(body);
+  if (!parsed) {
+    throw new Error("Template detail endpoint returned an invalid payload.");
+  }
+
+  return parsed;
 }
 
 export async function cloneTemplate(templateSlug: string): Promise<CloneTemplateResponse> {

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -18,6 +18,7 @@ import {
   SetupPdfStatus,
 } from "@/lib/setupPdf";
 import type { GraphMutationPayload } from "@/lib/graphDiff";
+import type { TemplateDetail } from "@/lib/templates";
 import { shouldApplyLayoutOnPipelineEvent } from "./pipelineLayout";
 import { shouldHydrateFromProject } from "./canvasHydration";
 
@@ -1346,6 +1347,31 @@ export function useCanvasPipeline(
     })();
   }
 
+  const loadTemplateSnapshot = useCallback(
+    (data: TemplateDetail) => {
+      hydrate(data.nodes, data.edges);
+      setTerraformFiles(data.terraform_files);
+      setCostEstimate(data.cost_estimate);
+      setArchDescription(data.arch_description);
+      setPipelineStatus("Template loaded");
+      setIsGenerating(false);
+      setCurrentStage("completed");
+      setLastEventAt(Date.now());
+      setTerraformProgress((prev) => ({
+        ...prev,
+        status: data.terraform_files.length > 0 ? "completed" : "idle",
+        activity: data.terraform_files.length > 0 ? "Terraform ready" : null,
+        emittedCount: data.terraform_files.length,
+        currentFile: null,
+        lastUpdateAt: Date.now(),
+      }));
+      if (hasInvalidNodePositions(data.nodes)) {
+        applyLayout();
+      }
+    },
+    [applyLayout, hydrate]
+  );
+
   return {
     ...diagram,
     messages: displayedMessages,
@@ -1382,5 +1408,6 @@ export function useCanvasPipeline(
     handleDeleteNodes,
     triggerGeneration,
     isDiscoveryMode,
+    loadTemplateSnapshot,
   };
 }

--- a/frontend/lib/useWorkspace.ts
+++ b/frontend/lib/useWorkspace.ts
@@ -15,7 +15,7 @@ import { getSupabaseBrowserClient } from "@/lib/supabase/browser";
 import { useCanvasPipeline } from "@/lib/useCanvasPipeline";
 import { useQuota } from "@/lib/useQuota";
 
-export type RightPanelTab = "output" | "designs";
+export type RightPanelTab = "output" | "designs" | "templates";
 
 function currentPathWithQuery() {
   if (typeof window === "undefined") return "/";
@@ -168,6 +168,11 @@ export function useWorkspace() {
     setRightPanelOpen(true);
   }, [fetchProjects, requireAuth]);
 
+  const openTemplates = useCallback(() => {
+    setRightPanelTab("templates");
+    setRightPanelOpen(true);
+  }, []);
+
   const openOutput = useCallback(() => {
     setRightPanelTab("output");
     setRightPanelOpen(true);
@@ -222,6 +227,7 @@ export function useWorkspace() {
     rightPanelOpen,
     rightPanelTab,
     openMyDesigns,
+    openTemplates,
     openOutput,
     closeRightPanel,
 


### PR DESCRIPTION
## Summary
- add backend template detail endpoint (`GET /api/templates/{slug}`) and extend template summaries with description
- add frontend template detail fetch/parser and in-place snapshot loading via canvas pipeline
- add Templates right-panel tab UI matching the requested design (fixed-height cards, compact description spacing, stacked scroll list)

## Verification
- `cd backend && uv run pytest tests/test_templates_endpoint.py -q`
- `cd frontend && pnpm exec vitest run lib/__tests__/templates.test.ts`
- `cd frontend && pnpm exec tsc --noEmit`