### PR TITLE
Fix Auto Layout to follow architect/template layout path

### DIFF
--- a/docs/superpowers/specs/2026-03-24-routing-layout-overhaul-design.md
+++ b/docs/superpowers/specs/2026-03-24-routing-layout-overhaul-design.md
@@ -32,7 +32,7 @@ Layout glue only (~50 lines). Renders `<TopBar>`, `<LeftPanel>`, `<Canvas>`, `<R
 - "Describe your app" button (placeholder — future issue)
 - "Templates" button (placeholder — opens right panel to templates, future issue)
 - "My Designs" button (opens right panel to project list)
-- "Auto Layout" button (placeholder)
+- "Auto Layout" button (triggers canvas layout)
 - "Generate Terraform" button (auth-gated)
 - User avatar / "Sign In" button (right side)
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,6 +8,7 @@ import LeftPanel from "@/components/LeftPanel";
 import RightPanel from "@/components/RightPanel";
 import TopBar from "@/components/TopBar";
 import { estimateCost } from "@/lib/costEstimator";
+import { canApplyManualLayout } from "@/lib/manualLayoutPolicy";
 import { useProjectDelete } from "@/lib/projectActions";
 import { fetchTemplateDetail } from "@/lib/templates";
 import { useWorkspace } from "@/lib/useWorkspace";
@@ -75,7 +76,16 @@ function WorkspaceContent() {
   }
 
   function handleAutoLayout() {
-    toast.message("Auto layout is coming in a follow-up issue.");
+    if (!canApplyManualLayout({ readOnly: canvasReadOnly, isGenerating: pipeline.isGenerating })) {
+      if (canvasReadOnly) {
+        toast.message("Auto Layout is disabled in read-only mode.");
+        return;
+      }
+      toast.message("Wait for generation to finish before auto layout.");
+      return;
+    }
+
+    pipeline.applyLayout();
   }
 
   function handleOpenProject(slug: string) {

--- a/frontend/lib/__tests__/manualLayoutPolicy.test.ts
+++ b/frontend/lib/__tests__/manualLayoutPolicy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { canApplyManualLayout } from "../manualLayoutPolicy";
+
+describe("canApplyManualLayout", () => {
+  it("blocks manual layout in read-only mode", () => {
+    expect(canApplyManualLayout({ readOnly: true, isGenerating: false })).toBe(false);
+  });
+
+  it("blocks manual layout while generation is active", () => {
+    expect(canApplyManualLayout({ readOnly: false, isGenerating: true })).toBe(false);
+  });
+
+  it("allows manual layout for editable idle sessions", () => {
+    expect(canApplyManualLayout({ readOnly: false, isGenerating: false })).toBe(true);
+  });
+});

--- a/frontend/lib/manualLayoutPolicy.ts
+++ b/frontend/lib/manualLayoutPolicy.ts
@@ -1,0 +1,10 @@
+type ManualLayoutPolicyInput = {
+  readOnly: boolean;
+  isGenerating: boolean;
+};
+
+export function canApplyManualLayout(input: ManualLayoutPolicyInput): boolean {
+  if (input.readOnly) return false;
+  if (input.isGenerating) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- wire the TopBar Auto Layout action to the existing `pipeline.applyLayout()` path used by architect completion and template fallback
- add manual layout gating so auto layout is blocked in read-only sessions and while generation is running
- add unit tests for manual layout policy and update the relevant spec note

## Verification
- `pnpm exec vitest run` (10 files, 48 tests passed)
- `pnpm exec tsc --noEmit` (passed)
- `pnpm lint` (passed; existing warning in `lib/useCanvasPipeline.ts:1009`)
- `pnpm build` was attempted but fails in this environment due missing Supabase env vars (`@supabase/ssr` URL/API key)

Closes #105