### PR TITLE
fix: remove auto coder agent from initial generation

### DIFF
--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -985,18 +985,11 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
         logger.info("Requirements extracted project_id=%s trace_id=%s", project_id, runtime.trace_id)
 
         await runtime.send_text(
-            json.dumps({"type": "status", "message": "Designing architecture and generating Terraform..."})
+            json.dumps({"type": "status", "message": "Designing architecture..."})
         )
 
         async def run_specialist_pass(pass_requirements: dict[str, Any]) -> dict[str, Any]:
             specialist_factories: dict[str, Callable[[], Awaitable[None]]] = {
-                "coder": lambda: stream_terraform_files(
-                    pass_requirements,
-                    runtime,
-                    start_time,
-                    diagram_nodes=diagram_nodes,
-                    llm_creds=llm_creds,
-                ),
                 "description": lambda: run_description_agent(
                     pass_requirements,
                     runtime,


### PR DESCRIPTION
## Summary
- Remove coder agent from `specialist_factories` in the initial `start_generation` flow so Terraform is no longer generated automatically after the architect finishes
- Update status message from "Designing architecture and generating Terraform..." to "Designing architecture..."
- Manual `generate_terraform` WS trigger and chat-driven `node_patch` rerun remain unaffected

Closes #116

## Test plan
- [ ] Run a new generation — verify only description agent runs after architect, no Terraform files emitted
- [ ] Click "Generate Terraform" button — verify Terraform files are generated
- [ ] Send a chat message that triggers `node_patch` — verify coder + description rerun as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)