### PR TITLE
Fix missing cost overlay hydration on project reopen

### DIFF
--- a/frontend/lib/__tests__/canvasHydration.test.ts
+++ b/frontend/lib/__tests__/canvasHydration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldHydrateFromProject } from "../canvasHydration";
+import { projectHydrationSnapshot, shouldHydrateFromProject } from "../canvasHydration";
 
 describe("shouldHydrateFromProject", () => {
   it("hydrates when session is fresh", () => {
@@ -78,5 +78,36 @@ describe("shouldHydrateFromProject", () => {
         wsState: "open",
       })
     ).toBe(true);
+  });
+});
+
+describe("projectHydrationSnapshot", () => {
+  it("includes persisted cost estimate data for hydration parity", () => {
+    const costEstimate = {
+      region: "us-east-1",
+      monthly_total: 99.2,
+      items: [],
+    };
+
+    const snapshot = projectHydrationSnapshot({
+      chatHistory: [{ role: "assistant", content: "hi" }],
+      terraformFiles: [{ filename: "main.tf", content: "", description: "" }],
+      archDescription: {
+        overview: "Overview",
+        key_components: "Components",
+        tradeoffs: "Tradeoffs",
+        next_steps: "Next",
+      },
+      costEstimate,
+      nodes: [{ id: "node-1", position: { x: 0, y: 0 }, data: {}, type: "service" }],
+      edges: [],
+      updatedAt: "2026-03-26T10:00:00.000Z",
+    });
+
+    expect(snapshot.costEstimate).toEqual(costEstimate);
+    expect(snapshot.chatHistory).toHaveLength(1);
+    expect(snapshot.terraformFiles).toHaveLength(1);
+    expect(snapshot.nodes).toHaveLength(1);
+    expect(snapshot.updatedAt).toBe("2026-03-26T10:00:00.000Z");
   });
 });

--- a/frontend/lib/canvasHydration.ts
+++ b/frontend/lib/canvasHydration.ts
@@ -1,4 +1,8 @@
 import type { ConnectionState } from "./websocket";
+import type { ArchDescription } from "@/components/ArchDescriptionViewer";
+import type { TerraformFile } from "@/components/OutputPanel";
+import type { CanvasMessage, CostBreakdown } from "@/lib/projects";
+import type { Edge, Node } from "reactflow";
 
 type ShouldHydrateFromProjectArgs = {
   isFreshSession: boolean;
@@ -31,4 +35,26 @@ export function shouldHydrateFromProject({
   }
 
   return true;
+}
+
+export type ProjectHydrationSnapshot = {
+  chatHistory: CanvasMessage[];
+  terraformFiles: TerraformFile[];
+  archDescription: ArchDescription | null;
+  costEstimate: CostBreakdown | null;
+  nodes: Node[];
+  edges: Edge[];
+  updatedAt: string;
+};
+
+export function projectHydrationSnapshot(project: ProjectHydrationSnapshot): ProjectHydrationSnapshot {
+  return {
+    chatHistory: project.chatHistory,
+    terraformFiles: project.terraformFiles,
+    archDescription: project.archDescription,
+    costEstimate: project.costEstimate,
+    nodes: project.nodes,
+    edges: project.edges,
+    updatedAt: project.updatedAt,
+  };
 }

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -22,7 +22,7 @@ import type { GraphMutationPayload } from "@/lib/graphDiff";
 import type { TemplateDetail } from "@/lib/templates";
 import { resolveGenerationProjectId } from "./generationSession";
 import { shouldApplyLayoutOnPipelineEvent } from "./pipelineLayout";
-import { shouldHydrateFromProject } from "./canvasHydration";
+import { projectHydrationSnapshot, shouldHydrateFromProject } from "./canvasHydration";
 import { createProject, saveSnapshot } from "./projectApi";
 
 export type AgentLogEntry = {
@@ -300,19 +300,21 @@ export function useCanvasPipeline(
 
     if (readOnly && canvasSession.mode === "existing") {
       if (isFreshSession || canvasSession.project.updatedAt !== lastHydratedUpdatedAtRef.current) {
-        setMessages(canvasSession.project.chatHistory);
-        setPendingArchitecturePlanId(latestPendingArchitecturePlanId(canvasSession.project.chatHistory));
-        setTerraformFiles(canvasSession.project.terraformFiles);
-        setArchDescription(canvasSession.project.archDescription);
+        const snapshot = projectHydrationSnapshot(canvasSession.project);
+        setMessages(snapshot.chatHistory);
+        setPendingArchitecturePlanId(latestPendingArchitecturePlanId(snapshot.chatHistory));
+        setTerraformFiles(snapshot.terraformFiles);
+        setArchDescription(snapshot.archDescription);
+        setCostEstimate(snapshot.costEstimate);
         setSetupPdfState(setupPdfStateFromProject(canvasSession.project));
         setIsChatStreaming(false);
         setStreamingAssistantReply("");
         streamingReplyRef.current = "";
-        hydrate(canvasSession.project.nodes, canvasSession.project.edges);
-        if (hasInvalidNodePositions(canvasSession.project.nodes)) {
+        hydrate(snapshot.nodes, snapshot.edges);
+        if (hasInvalidNodePositions(snapshot.nodes)) {
           applyLayout();
         }
-        lastHydratedUpdatedAtRef.current = canvasSession.project.updatedAt;
+        lastHydratedUpdatedAtRef.current = snapshot.updatedAt;
       }
 
       setTraceId(canvasSession.project.generationTraceId);
@@ -488,20 +490,21 @@ export function useCanvasPipeline(
       });
 
       if (shouldHydrateFromProjectState) {
-        setMessages(canvasSession.project.chatHistory);
-        setPendingArchitecturePlanId(latestPendingArchitecturePlanId(canvasSession.project.chatHistory));
-        setTerraformFiles(canvasSession.project.terraformFiles);
-        setArchDescription(canvasSession.project.archDescription);
-        setCostEstimate(canvasSession.project.costEstimate);
+        const snapshot = projectHydrationSnapshot(canvasSession.project);
+        setMessages(snapshot.chatHistory);
+        setPendingArchitecturePlanId(latestPendingArchitecturePlanId(snapshot.chatHistory));
+        setTerraformFiles(snapshot.terraformFiles);
+        setArchDescription(snapshot.archDescription);
+        setCostEstimate(snapshot.costEstimate);
         setSetupPdfState(setupPdfStateFromProject(canvasSession.project));
         setIsChatStreaming(false);
         setStreamingAssistantReply("");
         streamingReplyRef.current = "";
-        hydrate(canvasSession.project.nodes, canvasSession.project.edges);
-        if (hasInvalidNodePositions(canvasSession.project.nodes)) {
+        hydrate(snapshot.nodes, snapshot.edges);
+        if (hasInvalidNodePositions(snapshot.nodes)) {
           applyLayout();
         }
-        lastHydratedUpdatedAtRef.current = canvasSession.project.updatedAt;
+        lastHydratedUpdatedAtRef.current = snapshot.updatedAt;
       }
 
       setTraceId(canvasSession.project.generationTraceId);


### PR DESCRIPTION
## Summary
- hydrate persisted `costEstimate` in the read-only existing-project path
- centralize existing-project hydration fields via `projectHydrationSnapshot(...)` and reuse in both read-only and owner paths
- add a regression test that validates hydration parity includes `costEstimate`

## Test Plan
- `pnpm --dir frontend exec vitest run lib/__tests__`
- `pnpm --dir frontend lint` (passes with one pre-existing `react-hooks/exhaustive-deps` warning)

Fixes #129