### PR TITLE
fix(coder): resolve timeout layering regression

### DIFF
--- a/backend/agents/coder.py
+++ b/backend/agents/coder.py
@@ -31,10 +31,10 @@ _JSON_SINGLE_FILE_MAX_TOKENS = {
     "terraform.tfvars": 600,
 }
 _JSON_SINGLE_FILE_TIMEOUT_SECONDS = {
-    "main.tf": 70,
-    "variables.tf": 40,
-    "outputs.tf": 35,
-    "terraform.tfvars": 25,
+    "main.tf": 90,
+    "variables.tf": 60,
+    "outputs.tf": 50,
+    "terraform.tfvars": 40,
 }
 
 EMIT_TERRAFORM_TOOL = {

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -273,9 +273,9 @@ def _build_strict_budget_requirements(requirements: dict[str, Any], budget_cap: 
 _SPECIALIST_HEARTBEAT_SECONDS = 8.0
 _SPECIALIST_RETRY_CONFIG: dict[str, dict[str, float | int]] = {
     "coder": {
-        "max_retries": 0,
+        "max_retries": 1,
         "backoff_ms": 200,
-        "attempt_timeout_seconds": 210,
+        "attempt_timeout_seconds": 390,
     },
     "description": {
         "max_retries": 1,

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import generation_service
+from agents import coder as coder_agent
 
 
 class _FakePersistence:
@@ -60,10 +61,23 @@ def _stub_thumbnail_generation():
         yield
 
 
-def test_coder_specialist_budget_prioritizes_faster_completion():
+def test_coder_specialist_budget_supports_recovery_path():
     config = generation_service._specialist_config_for("coder")
-    assert int(config["max_retries"]) == 0
-    assert float(config["attempt_timeout_seconds"]) <= 240.0
+    assert int(config["max_retries"]) >= 1
+    assert float(config["attempt_timeout_seconds"]) >= 390.0
+
+
+def test_coder_specialist_timeout_budget_covers_inner_worst_case():
+    config = generation_service._specialist_config_for("coder")
+    outer_timeout = float(config["attempt_timeout_seconds"])
+
+    inner_worst_case = max(
+        coder_agent.TOOL_USE_TIMEOUT_SECONDS + coder_agent.FALLBACK_REQUEST_TIMEOUT_SECONDS,
+        max(coder_agent._JSON_SINGLE_FILE_TIMEOUT_SECONDS.values()) + coder_agent.FALLBACK_REQUEST_TIMEOUT_SECONDS,
+    )
+    safety_margin_seconds = 30.0
+
+    assert outer_timeout >= inner_worst_case + safety_margin_seconds
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore coder retry budget and increase outer timeout to 390s so fallback paths are not canceled by the stage timeout
- relax bounded single-file JSON timeouts to reduce `coder.json_timeout ... fallback=False` churn
- add regression tests that enforce timeout-layer budget coherence and coder recovery expectations

## Test Plan
- [x] `cd backend && uv run pytest tests/test_generation_service.py tests/agents/test_coder.py tests/test_generation_service_byok.py -q`

Fixes #132