### PR TITLE
Fix redirect when generation targets a new project

### DIFF
--- a/frontend/lib/__tests__/workspaceRedirect.test.ts
+++ b/frontend/lib/__tests__/workspaceRedirect.test.ts
@@ -10,7 +10,8 @@ describe("shouldRedirectOnProjectReady", () => {
       shouldRedirectOnProjectReady({
         shareSlug: null,
         projectSlug: null,
-        hasCurrentProject: false,
+        currentProjectId: null,
+        readyProjectId: null,
       })
     ).toBe(false);
   });
@@ -20,19 +21,32 @@ describe("shouldRedirectOnProjectReady", () => {
       shouldRedirectOnProjectReady({
         shareSlug: "same-slug",
         projectSlug: "same-slug",
-        hasCurrentProject: false,
+        currentProjectId: null,
+        readyProjectId: "project-1",
       })
     ).toBe(false);
   });
 
-  it("returns false when a current project is already loaded", () => {
+  it("returns false when ready project id matches the current project id", () => {
     expect(
       shouldRedirectOnProjectReady({
         shareSlug: "new-slug",
         projectSlug: "old-slug",
-        hasCurrentProject: true,
+        currentProjectId: "project-1",
+        readyProjectId: "project-1",
       })
     ).toBe(false);
+  });
+
+  it("returns true when a different project id is ready", () => {
+    expect(
+      shouldRedirectOnProjectReady({
+        shareSlug: "new-slug",
+        projectSlug: "old-slug",
+        currentProjectId: "project-1",
+        readyProjectId: "project-2",
+      })
+    ).toBe(true);
   });
 
   it("returns true when a new slug is ready and no current project exists", () => {
@@ -40,9 +54,21 @@ describe("shouldRedirectOnProjectReady", () => {
       shouldRedirectOnProjectReady({
         shareSlug: "new-slug",
         projectSlug: null,
-        hasCurrentProject: false,
+        currentProjectId: null,
+        readyProjectId: "project-2",
       })
     ).toBe(true);
+  });
+
+  it("returns false when ready project id is missing and a current project exists", () => {
+    expect(
+      shouldRedirectOnProjectReady({
+        shareSlug: "new-slug",
+        projectSlug: "old-slug",
+        currentProjectId: "project-1",
+        readyProjectId: null,
+      })
+    ).toBe(false);
   });
 });
 

--- a/frontend/lib/useWorkspace.ts
+++ b/frontend/lib/useWorkspace.ts
@@ -62,12 +62,13 @@ export function useWorkspace() {
   }, [currentProject]);
 
   const handleProjectReady = useCallback(
-    (_projectId: string, shareSlug: string | null) => {
+    (projectId: string, shareSlug: string | null) => {
       if (
         !shouldRedirectOnProjectReady({
           shareSlug,
           projectSlug,
-          hasCurrentProject: Boolean(currentProject),
+          currentProjectId: currentProject?.id ?? null,
+          readyProjectId: projectId,
         })
       ) {
         return;

--- a/frontend/lib/workspaceRedirect.ts
+++ b/frontend/lib/workspaceRedirect.ts
@@ -1,7 +1,8 @@
 type ProjectReadyRedirectInput = {
   shareSlug: string | null;
   projectSlug: string | null;
-  hasCurrentProject: boolean;
+  currentProjectId: string | null;
+  readyProjectId: string | null;
 };
 
 type UnauthenticatedRootRedirectInput = {
@@ -13,11 +14,14 @@ type UnauthenticatedRootRedirectInput = {
 export function shouldRedirectOnProjectReady({
   shareSlug,
   projectSlug,
-  hasCurrentProject,
+  currentProjectId,
+  readyProjectId,
 }: ProjectReadyRedirectInput): boolean {
   if (!shareSlug) return false;
   if (shareSlug === projectSlug) return false;
-  if (hasCurrentProject) return false;
+  if (!currentProjectId) return true;
+  if (!readyProjectId) return false;
+  if (readyProjectId === currentProjectId) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- make project-ready redirect logic project-aware instead of only checking whether any project is loaded
- redirect when `project_ready.project_id` differs from the currently loaded project id
- keep same-project `project_ready` events on the current route
- update redirect tests to cover same-project vs different-project behavior

## Why
Generation from an existing workspace can intentionally create a new project (`forceNewProject: true`).
Without redirecting to the returned slug/project, the canvas stays bound to the old project and drops websocket events from the new one.

Closes #155
