### PR TITLE
fix(cost): improve unpriced note to explain internal K8s components

### DIFF
--- a/frontend/lib/__tests__/costOverlayPresentation.test.ts
+++ b/frontend/lib/__tests__/costOverlayPresentation.test.ts
@@ -17,7 +17,7 @@ describe("buildCostOverlayPresentation", () => {
 
     expect(presentation.hidden).toBe(false);
     expect(presentation.totalLabel).toBe("~$0/mo");
-    expect(presentation.note).toBe("Some services could not be priced yet.");
+    expect(presentation.note).toBe("Some items are internal components (e.g. controllers, pods) and don't have direct AWS costs.");
   });
 
   it("shows normal totals for priced estimates", () => {

--- a/frontend/lib/costOverlayPresentation.ts
+++ b/frontend/lib/costOverlayPresentation.ts
@@ -35,13 +35,13 @@ export function buildCostOverlayPresentation(costEstimate: CostBreakdown | null)
     return {
       hidden: false,
       totalLabel: "~$0/mo",
-      note: hasUnpricedItems ? "Some services could not be priced yet." : null,
+      note: hasUnpricedItems ? "Some items are internal components (e.g. controllers, pods) and don't have direct AWS costs." : null,
     };
   }
 
   return {
     hidden: false,
     totalLabel: `${formatMoney(costEstimate.monthly_total)}/mo`,
-    note: hasUnpricedItems ? "Some services could not be priced yet." : null,
+    note: hasUnpricedItems ? "Some items are internal components (e.g. controllers, pods) and don't have direct AWS costs." : null,
   };
 }


### PR DESCRIPTION
## Summary
- Replace vague \"Some services could not be priced yet.\" with specific explanation for internal K8s components
- Updated test to match new message