### PR TITLE
Fix multi-region generation parent-node crash on frontend

### DIFF
--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -14,7 +14,8 @@ ARCHITECT_SYSTEM = """You are an AWS architecture diagram generator for DrawToCl
 Given a requirements JSON, output diagram events — one per line — describing a complete AWS architecture.
 
 Each line must be a valid JSON object in one of these formats:
-{"action": "add_node", "id": "vpc", "label": "VPC", "category": "network", "node_type": "container", "container_type": "vpc"}
+{"action": "add_node", "id": "us_east_1", "label": "US East 1", "category": "network", "node_type": "container", "container_type": "region"}
+{"action": "add_node", "id": "vpc", "label": "VPC", "category": "network", "node_type": "container", "container_type": "vpc", "parent_id": "us_east_1"}
 {"action": "add_node", "id": "az_a", "label": "Availability Zone A", "category": "network", "node_type": "container", "container_type": "az", "parent_id": "vpc"}
 {"action": "add_node", "id": "private_subnet_a", "label": "Private Subnet", "category": "network", "node_type": "container", "container_type": "subnet", "parent_id": "az_a"}
 {"action": "add_node", "id": "ecs", "label": "ECS Service", "category": "compute", "node_type": "service", "parent_id": "private_subnet_a", "aws_service_code": "AmazonECS", "instance_type": "t3.small"}
@@ -24,10 +25,15 @@ Node categories: network | compute | database | storage | security | monitoring
 
 Rules:
 - Output nodes in dependency order: network → compute → data → monitoring
-- VPC is always first. Use node_type "container" and container_type "vpc" on VPC.
+- For multi-region architectures: emit one region container per region, then nest VPCs inside the region they belong to.
+  Use parent order `region -> vpc -> az -> subnet -> services`. Region is root-level only.
+  Use container_type "region" for region containers. Derive region node IDs from the AWS region code (e.g. "us_east_1", "eu_central_1").
+  When `multi_region` is true or more than one region is requested, emit a region container for each region.
+- For single-region architectures: region container is optional. You may start directly with VPC.
+- VPC is always the first service-scoped container. Use node_type "container" and container_type "vpc" on VPC.
 - Availability Zones and Subnets may also be emitted as containers when they clarify the architecture.
-- For nested network structures, use parent order `vpc -> az -> subnet -> services`.
-- Use `container_type` only for container nodes: `vpc` | `az` | `subnet`.
+- For nested network structures (single region), use parent order `vpc -> az -> subnet -> services`.
+- Use `container_type` only for container nodes: `region` | `vpc` | `az` | `subnet`.
 - Services inside nested containers must use the deepest relevant parent_id (prefer subnet over az over vpc).
 - Simple architectures may keep services directly under VPC when extra nesting does not add value.
 - Services outside VPC (CloudWatch, Route53, S3 if external): omit parent_id.

--- a/backend/tests/agents/test_architect.py
+++ b/backend/tests/agents/test_architect.py
@@ -223,3 +223,44 @@ def test_architect_prompt_supports_nested_container_types():
     assert 'container_type": "az", "parent_id": "vpc", "aws_service_code"' not in ARCHITECT_SYSTEM
     assert 'container_type": "subnet", "parent_id": "az_a", "aws_service_code"' not in ARCHITECT_SYSTEM
     assert "add `aws_service_code` for service nodes only" in ARCHITECT_SYSTEM
+
+
+def test_architect_prompt_supports_region_container_type():
+    """The architect prompt must include region as a container type for multi-region architectures."""
+    from agents.architect import ARCHITECT_SYSTEM
+
+    assert 'container_type": "region"' in ARCHITECT_SYSTEM, (
+        "Architect prompt must define region as a supported container_type for multi-region diagrams"
+    )
+    assert "region -> vpc" in ARCHITECT_SYSTEM or "vpc -> region" not in ARCHITECT_SYSTEM, (
+        "Architect prompt must document that region is emitted before its child VPC"
+    )
+    assert "multi-region" in ARCHITECT_SYSTEM.lower() or "multi_region" in ARCHITECT_SYSTEM.lower(), (
+        "Architect prompt must discuss multi-region architecture output rules"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_architecture_supports_multi_region_with_region_parent():
+    """A multi-region stream emitting region -> vpc -> service should send all events with correct parent_id."""
+    mock_ws = AsyncMock()
+
+    async def multi_region_stream(*args, **kwargs):
+        yield '{"action": "add_node", "id": "eu_central_1", "label": "EU Central 1", "category": "network", "node_type": "container", "container_type": "region"}\n'
+        yield '{"action": "add_node", "id": "vpc_eu", "label": "VPC EU", "category": "network", "node_type": "container", "container_type": "vpc", "parent_id": "eu_central_1"}\n'
+        yield '{"action": "add_node", "id": "ecs_eu", "label": "ECS EU", "category": "compute", "node_type": "service", "parent_id": "vpc_eu"}\n'
+        yield '{"action": "add_edge", "from": "vpc_eu", "to": "ecs_eu", "label": "contains"}\n'
+
+    with patch("agents.architect.async_stream_text", multi_region_stream):
+        with patch("agents.architect.asyncio.sleep", return_value=None):
+            from agents.architect import stream_architecture
+            await stream_architecture({"multi_region": True}, mock_ws)
+
+    calls = [json.loads(c.args[0]) for c in mock_ws.send_text.call_args_list]
+    diagram_events = [p for p in calls if p.get("type") == "diagram_event"]
+
+    # region node is emitted before vpc, vpc before service
+    node_events = [e for e in diagram_events if e.get("action") == "add_node"]
+    node_ids = [e.get("id") for e in node_events]
+    assert node_ids.index("eu_central_1") < node_ids.index("vpc_eu"), "region must come before vpc"
+    assert node_ids.index("vpc_eu") < node_ids.index("ecs_eu"), "vpc must come before service"

--- a/backend/tests/agents/test_architect.py
+++ b/backend/tests/agents/test_architect.py
@@ -232,8 +232,11 @@ def test_architect_prompt_supports_region_container_type():
     assert 'container_type": "region"' in ARCHITECT_SYSTEM, (
         "Architect prompt must define region as a supported container_type for multi-region diagrams"
     )
-    assert "region -> vpc" in ARCHITECT_SYSTEM or "vpc -> region" not in ARCHITECT_SYSTEM, (
-        "Architect prompt must document that region is emitted before its child VPC"
+    assert "region -> vpc" in ARCHITECT_SYSTEM, (
+        "Architect prompt must document the correct region-before-VPC ordering"
+    )
+    assert "vpc -> region" not in ARCHITECT_SYSTEM, (
+        "Architect prompt must not document the incorrect VPC-before-region ordering"
     )
     assert "multi-region" in ARCHITECT_SYSTEM.lower() or "multi_region" in ARCHITECT_SYSTEM.lower(), (
         "Architect prompt must discuss multi-region architecture output rules"
@@ -262,5 +265,9 @@ async def test_stream_architecture_supports_multi_region_with_region_parent():
     # region node is emitted before vpc, vpc before service
     node_events = [e for e in diagram_events if e.get("action") == "add_node"]
     node_ids = [e.get("id") for e in node_events]
+    node_by_id = {e["id"]: e for e in node_events}
     assert node_ids.index("eu_central_1") < node_ids.index("vpc_eu"), "region must come before vpc"
     assert node_ids.index("vpc_eu") < node_ids.index("ecs_eu"), "vpc must come before service"
+    assert "parent_id" not in node_by_id["eu_central_1"], "region node must not declare a parent_id"
+    assert node_by_id["vpc_eu"].get("parent_id") == "eu_central_1", "vpc must reference region as parent"
+    assert node_by_id["ecs_eu"].get("parent_id") == "vpc_eu", "service must reference vpc as parent"

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -197,6 +197,97 @@ async def test_emit_canvas_snapshot_replays_container_type_and_nested_parent_ids
 
 
 @pytest.mark.asyncio
+async def test_generation_runtime_persists_region_container_type():
+    """Region containers must be persisted with type=container and containerType=region."""
+    runtime = generation_service.GenerationRuntime(
+        project_id="project-123",
+        user_id="user-123",
+        trace_id="trace-123",
+        is_admin=True,
+        persistence=generation_service.PersistenceState("project-123", "user-123"),
+        broadcaster=_FakeBroadcaster(),
+    )
+
+    await runtime.send_text(json.dumps({
+        "type": "diagram_event",
+        "action": "add_node",
+        "id": "eu_central_1",
+        "label": "EU Central 1",
+        "category": "network",
+        "node_type": "container",
+        "container_type": "region",
+    }))
+
+    assert runtime.persistence.nodes == [
+        {
+            "id": "eu_central_1",
+            "type": "container",
+            "position": {"x": 0, "y": 0},
+            "data": {"label": "EU Central 1", "category": "network", "containerType": "region"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emit_canvas_snapshot_replays_region_containers_with_nested_children():
+    """A region -> vpc hierarchy must survive snapshot replay with correct container_type and parent_id."""
+    runtime = _FakeRuntime()
+
+    await generation_service._emit_canvas_snapshot(
+        runtime,
+        nodes=[
+            {
+                "id": "eu_central_1",
+                "type": "container",
+                "position": {"x": 0, "y": 0},
+                "style": {"width": 860, "height": 640},
+                "data": {"label": "EU Central 1", "category": "network", "containerType": "region"},
+            },
+            {
+                "id": "vpc_eu",
+                "type": "container",
+                "position": {"x": 40, "y": 40},
+                "style": {"width": 700, "height": 500},
+                "parentId": "eu_central_1",
+                "extent": "parent",
+                "data": {"label": "VPC EU", "category": "network", "containerType": "vpc"},
+            },
+            {
+                "id": "az_eu_a",
+                "type": "container",
+                "position": {"x": 40, "y": 40},
+                "style": {"width": 500, "height": 400},
+                "parentId": "vpc_eu",
+                "extent": "parent",
+                "data": {"label": "AZ EU A", "category": "network", "containerType": "az"},
+            },
+        ],
+        edges=[],
+        cost_estimate=None,
+    )
+
+    diagram_events = [payload for payload in runtime.sent_payloads if payload.get("type") == "diagram_event"]
+    # Three add_node events: region, vpc, az
+    add_nodes = [e for e in diagram_events if e.get("action") == "add_node"]
+    assert len(add_nodes) == 3
+
+    # Region emitted first, with container_type "region"
+    assert add_nodes[0]["id"] == "eu_central_1"
+    assert add_nodes[0]["container_type"] == "region"
+    assert "parent_id" not in add_nodes[0]
+
+    # VPC is parented to region
+    assert add_nodes[1]["id"] == "vpc_eu"
+    assert add_nodes[1]["parent_id"] == "eu_central_1"
+    assert add_nodes[1]["container_type"] == "vpc"
+
+    # AZ is parented to VPC
+    assert add_nodes[2]["id"] == "az_eu_a"
+    assert add_nodes[2]["parent_id"] == "vpc_eu"
+    assert add_nodes[2]["container_type"] == "az"
+
+
+@pytest.mark.asyncio
 async def test_emit_canvas_snapshot_replays_service_pricing_metadata_without_tagging_containers():
     runtime = _FakeRuntime()
 

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -643,7 +643,7 @@ Nested container example:
 
 Fields:
 - `node_type`: `"service"` (default) | `"container"`.
-- `container_type`: optional. Only valid for container nodes: `"vpc"` | `"az"` | `"subnet"`.
+- `container_type`: optional. Only valid for container nodes: `"region"` | `"vpc"` | `"az"` | `"subnet"`.
 - `parent_id`: optional. ID of the parent container for services and nested containers.
 - `position`: optional on replayed snapshots. Uses persisted React Flow coordinates.
 - `style`: optional on replayed container snapshots. Carries persisted width/height.

--- a/frontend/lib/__tests__/diagramEventBuffer.test.ts
+++ b/frontend/lib/__tests__/diagramEventBuffer.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseDiagramEvent,
+  classifyNodeEvent,
+  type DiagramEvent,
+  type AddNodeEvent,
+  type NodeExistsCheck,
+} from "../diagramEventBuffer";
+
+function existingSet(ids: string[]): NodeExistsCheck {
+  const set = new Set(ids);
+  return { hasNode: (id: string) => set.has(id) };
+}
+
+describe("classifyNodeEvent", () => {
+  it("applies a node when its parent already exists", () => {
+    const event: AddNodeEvent = {
+      type: "add_node",
+      id: "ecs",
+      label: "ECS",
+      category: "compute",
+      node_type: "service",
+      parent_id: "vpc",
+    };
+
+    const result = classifyNodeEvent(event, existingSet(["vpc"]));
+
+    expect(result.action).toBe("apply");
+  });
+
+  it("defers a node when its parent does not exist yet", () => {
+    const event: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc",
+      label: "VPC",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+      parent_id: "eu_central_1",
+    };
+
+    const result = classifyNodeEvent(event, existingSet([]));
+
+    expect(result.action).toBe("defer");
+    if (result.action === "defer") {
+      expect(result.missingParentId).toBe("eu_central_1");
+    }
+  });
+
+  it("applies a root node with no parent_id regardless of existing nodes", () => {
+    const event: AddNodeEvent = {
+      type: "add_node",
+      id: "eu_central_1",
+      label: "EU Central 1",
+      category: "network",
+      node_type: "container",
+      container_type: "region",
+    };
+
+    const result = classifyNodeEvent(event, existingSet([]));
+
+    expect(result.action).toBe("apply");
+  });
+
+  it("skips a duplicate node id", () => {
+    const event: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc",
+      label: "VPC Copy",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+    };
+
+    const result = classifyNodeEvent(event, existingSet(["vpc"]));
+
+    expect(result.action).toBe("skip_duplicate");
+  });
+
+  it("handles multi-region: region then vpc then service — correct ordering", () => {
+    let existing: string[] = [];
+
+    // Step 1: region arrives (root, no parent)
+    const regionEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "eu_central_1",
+      label: "EU Central 1",
+      category: "network",
+      node_type: "container",
+      container_type: "region",
+    };
+    const r1 = classifyNodeEvent(regionEvent, existingSet(existing));
+    expect(r1.action).toBe("apply");
+    existing.push("eu_central_1");
+
+    // Step 2: VPC arrives referencing region (parent exists)
+    const vpcEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc_eu",
+      label: "VPC EU",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+      parent_id: "eu_central_1",
+    };
+    const r2 = classifyNodeEvent(vpcEvent, existingSet(existing));
+    expect(r2.action).toBe("apply");
+    existing.push("vpc_eu");
+
+    // Step 3: Service arrives referencing vpc (parent exists)
+    const svcEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "ecs_eu",
+      label: "ECS EU",
+      category: "compute",
+      node_type: "service",
+      parent_id: "vpc_eu",
+    };
+    const r3 = classifyNodeEvent(svcEvent, existingSet(existing));
+    expect(r3.action).toBe("apply");
+  });
+
+  it("defers vpc when parent region has not been streamed yet", () => {
+    const vpcEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc_eu",
+      label: "VPC EU",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+      parent_id: "eu_central_1",
+    };
+
+    const result = classifyNodeEvent(vpcEvent, existingSet([]));
+    expect(result.action).toBe("defer");
+  });
+});
+
+describe("parseDiagramEvent", () => {
+  it("parses a valid add_node event", () => {
+    const event = parseDiagramEvent({
+      action: "add_node",
+      id: "ecs",
+      label: "ECS",
+      category: "compute",
+      node_type: "service",
+      parent_id: "vpc",
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe("add_node");
+    if (event?.type === "add_node") {
+      expect(event.id).toBe("ecs");
+      expect(event.parent_id).toBe("vpc");
+    }
+  });
+
+  it("returns null for missing id", () => {
+    const event = parseDiagramEvent({
+      action: "add_node",
+      label: "ECS",
+    });
+    expect(event).toBeNull();
+  });
+
+  it("parses a valid add_edge event", () => {
+    const event = parseDiagramEvent({
+      action: "add_edge",
+      from: "alb",
+      to: "ecs",
+      label: "routes to",
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe("add_edge");
+    if (event?.type === "add_edge") {
+      expect(event.from).toBe("alb");
+      expect(event.to).toBe("ecs");
+    }
+  });
+
+  it("returns null for unknown action", () => {
+    const event = parseDiagramEvent({ action: "remove_node", id: "x" });
+    expect(event).toBeNull();
+  });
+});

--- a/frontend/lib/__tests__/diagramEventBuffer.test.ts
+++ b/frontend/lib/__tests__/diagramEventBuffer.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   parseDiagramEvent,
   classifyNodeEvent,
+  createEventBuffer,
+  bufferDeferredEvent,
+  drainDeferredEvents,
   type DiagramEvent,
   type AddNodeEvent,
   type NodeExistsCheck,
@@ -183,5 +186,109 @@ describe("parseDiagramEvent", () => {
   it("returns null for unknown action", () => {
     const event = parseDiagramEvent({ action: "remove_node", id: "x" });
     expect(event).toBeNull();
+  });
+});
+
+describe("EventBuffer", () => {
+  it("buffers a deferred event under the missing parent key", () => {
+    const vpcEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc_eu",
+      label: "VPC EU",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+      parent_id: "eu_central_1",
+    };
+
+    let buffer = createEventBuffer();
+    buffer = bufferDeferredEvent(buffer, vpcEvent, "eu_central_1");
+
+    expect(buffer.deferred.has("eu_central_1")).toBe(true);
+    expect(buffer.deferred.get("eu_central_1")).toHaveLength(1);
+  });
+
+  it("drains deferred events when parent becomes available", () => {
+    const vpcEvent: AddNodeEvent = {
+      type: "add_node",
+      id: "vpc_eu",
+      label: "VPC EU",
+      category: "network",
+      node_type: "container",
+      container_type: "vpc",
+      parent_id: "eu_central_1",
+    };
+
+    let buffer = createEventBuffer();
+    buffer = bufferDeferredEvent(buffer, vpcEvent, "eu_central_1");
+
+    const { events, buffer: nextBuffer } = drainDeferredEvents(buffer, "eu_central_1");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe("vpc_eu");
+    expect(nextBuffer.deferred.has("eu_central_1")).toBe(false);
+  });
+
+  it("returns empty for unknown parent key", () => {
+    const buffer = createEventBuffer();
+    const { events } = drainDeferredEvents(buffer, "nonexistent");
+    expect(events).toHaveLength(0);
+  });
+
+  it("supports multiple deferred events for the same parent", () => {
+    const vpc1: AddNodeEvent = {
+      type: "add_node", id: "vpc_eu", label: "VPC EU", category: "network",
+      node_type: "container", container_type: "vpc", parent_id: "eu_central_1",
+    };
+    const vpc2: AddNodeEvent = {
+      type: "add_node", id: "vpc_us", label: "VPC US", category: "network",
+      node_type: "container", container_type: "vpc", parent_id: "eu_central_1",
+    };
+
+    let buffer = createEventBuffer();
+    buffer = bufferDeferredEvent(buffer, vpc1, "eu_central_1");
+    buffer = bufferDeferredEvent(buffer, vpc2, "eu_central_1");
+
+    const { events } = drainDeferredEvents(buffer, "eu_central_1");
+    expect(events).toHaveLength(2);
+  });
+
+  it("simulates out-of-order streaming: child before parent, then parent arrives", () => {
+    let existing: string[] = [];
+    let buffer = createEventBuffer();
+    const applied: AddNodeEvent[] = [];
+
+    // Step 1: VPC arrives referencing region that doesn't exist
+    const vpcEvent: AddNodeEvent = {
+      type: "add_node", id: "vpc_eu", label: "VPC EU", category: "network",
+      node_type: "container", container_type: "vpc", parent_id: "eu_central_1",
+    };
+    const c1 = classifyNodeEvent(vpcEvent, existingSet(existing));
+    expect(c1.action).toBe("defer");
+    buffer = bufferDeferredEvent(buffer, vpcEvent, (c1 as { missingParentId: string }).missingParentId);
+
+    // Step 2: Region arrives (root node)
+    const regionEvent: AddNodeEvent = {
+      type: "add_node", id: "eu_central_1", label: "EU Central 1", category: "network",
+      node_type: "container", container_type: "region",
+    };
+    const c2 = classifyNodeEvent(regionEvent, existingSet(existing));
+    expect(c2.action).toBe("apply");
+    applied.push(regionEvent);
+    existing.push("eu_central_1");
+
+    // Step 3: Drain deferred events for the newly available region
+    const { events: drained, buffer: nextBuffer } = drainDeferredEvents(buffer, "eu_central_1");
+    buffer = nextBuffer;
+
+    // Step 4: Process each drained event
+    for (const event of drained) {
+      const c = classifyNodeEvent(event, existingSet(existing));
+      expect(c.action).toBe("apply");
+      applied.push(event);
+      existing.push(event.id);
+    }
+
+    expect(applied.map((e) => e.id)).toEqual(["eu_central_1", "vpc_eu"]);
   });
 });

--- a/frontend/lib/diagramEventBuffer.ts
+++ b/frontend/lib/diagramEventBuffer.ts
@@ -1,0 +1,81 @@
+export type AddNodeEvent = {
+  type: "add_node";
+  id: string;
+  label: string;
+  category: string;
+  node_type: string;
+  container_type?: string;
+  parent_id?: string;
+  subnet_kind?: string;
+  position?: { x?: unknown; y?: unknown };
+  style?: Record<string, unknown>;
+};
+
+export type AddEdgeEvent = {
+  type: "add_edge";
+  from: string;
+  to: string;
+  label?: string;
+};
+
+export type DiagramEvent = AddNodeEvent | AddEdgeEvent;
+
+export function parseDiagramEvent(msg: Record<string, unknown>): DiagramEvent | null {
+  if (msg.action === "add_node") {
+    const id = typeof msg.id === "string" ? msg.id : "";
+    const label = typeof msg.label === "string" ? msg.label : "";
+    const category = typeof msg.category === "string" ? msg.category : "compute";
+    const nodeType = typeof msg.node_type === "string" ? msg.node_type : "service";
+    if (!id) return null;
+    return {
+      type: "add_node",
+      id,
+      label: label || id,
+      category,
+      node_type: nodeType,
+      container_type: typeof msg.container_type === "string" ? msg.container_type : undefined,
+      parent_id: typeof msg.parent_id === "string" ? msg.parent_id : undefined,
+      subnet_kind: typeof msg.subnet_kind === "string" ? msg.subnet_kind : undefined,
+      position:
+        typeof msg.position === "object" && msg.position !== null
+          ? (msg.position as { x?: unknown; y?: unknown })
+          : undefined,
+      style: typeof msg.style === "object" && msg.style !== null ? (msg.style as Record<string, unknown>) : undefined,
+    };
+  }
+
+  if (msg.action === "add_edge") {
+    const from = typeof msg.from === "string" ? msg.from : "";
+    const to = typeof msg.to === "string" ? msg.to : "";
+    if (!from || !to) return null;
+    return {
+      type: "add_edge",
+      from,
+      to,
+      label: typeof msg.label === "string" ? msg.label : "",
+    };
+  }
+
+  return null;
+}
+
+export interface NodeExistsCheck {
+  hasNode(id: string): boolean;
+}
+
+export type ApplyAction =
+  | { action: "skip_duplicate"; eventId: string }
+  | { action: "defer"; eventId: string; missingParentId: string }
+  | { action: "apply"; eventId: string };
+
+export function classifyNodeEvent(event: AddNodeEvent, existingNodes: NodeExistsCheck): ApplyAction {
+  if (existingNodes.hasNode(event.id)) {
+    return { action: "skip_duplicate", eventId: event.id };
+  }
+
+  if (event.parent_id && !existingNodes.hasNode(event.parent_id)) {
+    return { action: "defer", eventId: event.id, missingParentId: event.parent_id };
+  }
+
+  return { action: "apply", eventId: event.id };
+}

--- a/frontend/lib/diagramEventBuffer.ts
+++ b/frontend/lib/diagramEventBuffer.ts
@@ -79,3 +79,30 @@ export function classifyNodeEvent(event: AddNodeEvent, existingNodes: NodeExists
 
   return { action: "apply", eventId: event.id };
 }
+
+export interface EventBuffer {
+  deferred: Map<string, AddNodeEvent[]>;
+}
+
+export function createEventBuffer(): EventBuffer {
+  return { deferred: new Map() };
+}
+
+export function bufferDeferredEvent(buffer: EventBuffer, event: AddNodeEvent, missingParentId: string): EventBuffer {
+  const existing = buffer.deferred.get(missingParentId) ?? [];
+  return {
+    deferred: new Map(buffer.deferred).set(missingParentId, [...existing, event]),
+  };
+}
+
+export function drainDeferredEvents(buffer: EventBuffer, newlyAvailableId: string): {
+  events: AddNodeEvent[];
+  buffer: EventBuffer;
+} {
+  const events = buffer.deferred.get(newlyAvailableId) ?? [];
+  if (events.length === 0) return { events, buffer };
+
+  const next = new Map(buffer.deferred);
+  next.delete(newlyAvailableId);
+  return { events, buffer: { deferred: next } };
+}

--- a/frontend/lib/useDiagramState.ts
+++ b/frontend/lib/useDiagramState.ts
@@ -240,6 +240,7 @@ export function useDiagramState() {
     setManualPositionOverrides(cleared);
     nodesRef.current = normalizedNodes;
     edgesRef.current = normalizedEdges;
+    eventBufferRef.current = createEventBuffer();
     setFitViewTrigger((v) => v + 1);
   }, []);
 
@@ -258,6 +259,7 @@ export function useDiagramState() {
     setManualPositionOverrides(cleared);
     nodesRef.current = normalizedNodes;
     edgesRef.current = normalizedEdges;
+    eventBufferRef.current = createEventBuffer();
     setFitViewTrigger((v) => v + 1);
     return { ok: true };
   }, []);

--- a/frontend/lib/useDiagramState.ts
+++ b/frontend/lib/useDiagramState.ts
@@ -7,6 +7,7 @@ import { buildContainerNodeData } from "@/lib/containerNodeData";
 import { applyGraphDiff, GraphMutationPayload } from "@/lib/graphDiff";
 import { applyDiagramNodeChanges } from "@/lib/diagramPresentationState";
 import { clearManualPositionOverrides, type ManualPositionOverrides } from "@/lib/manualNodePositions";
+import { classifyNodeEvent, parseDiagramEvent, type AddNodeEvent } from "@/lib/diagramEventBuffer";
 
 function normalizeNode(node: Node): Node {
   const id = String(node.id ?? "");
@@ -116,19 +117,29 @@ export function useDiagramState() {
 
   const handleDiagramEvent = useCallback((msg: Record<string, unknown>) => {
     if (msg.action === "add_node") {
-      const id = msg.id as string;
-      const label = msg.label as string;
-      const category = (msg.category as string) ?? "compute";
-      const isContainer = (msg.node_type as string) === "container";
-      const containerType = normalizeContainerType(msg.container_type);
-      const parentId = msg.parent_id as string | undefined;
-      const position = typeof msg.position === "object" && msg.position !== null
+      const parsed = parseDiagramEvent(msg);
+      if (!parsed || parsed.type !== "add_node") return;
+
+      const action = classifyNodeEvent(parsed, {
+        hasNode: (id: string) => nodesRef.current.some((n) => n.id === id),
+      });
+
+      if (action.action === "skip_duplicate") return;
+      if (action.action === "defer") return;
+
+      const id = parsed.id;
+      const label = parsed.label;
+      const category = parsed.category;
+      const isContainer = parsed.node_type === "container";
+      const containerType = normalizeContainerType(parsed.container_type);
+      const parentId = parsed.parent_id;
+      const position = typeof parsed.position === "object" && parsed.position !== null
         ? {
-            x: Number.isFinite((msg.position as { x?: unknown }).x) ? Number((msg.position as { x?: number }).x) : 0,
-            y: Number.isFinite((msg.position as { y?: unknown }).y) ? Number((msg.position as { y?: number }).y) : 0,
+            x: Number.isFinite((parsed.position as { x?: unknown }).x) ? Number((parsed.position as { x?: number }).x) : 0,
+            y: Number.isFinite((parsed.position as { y?: unknown }).y) ? Number((parsed.position as { y?: number }).y) : 0,
           }
         : { x: 0, y: 0 };
-      const style = typeof msg.style === "object" && msg.style !== null ? msg.style as Node["style"] : undefined;
+      const style = typeof parsed.style === "object" && parsed.style !== null ? parsed.style as Node["style"] : undefined;
 
       setCanonicalNodes((prev) => {
         if (prev.find((n) => n.id === id)) return prev;
@@ -137,7 +148,7 @@ export function useDiagramState() {
               id, type: "container", position,
               ...(parentId ? { parentId, extent: "parent" as const } : {}),
               style: { ...defaultContainerSize(containerType), ...style },
-              data: buildContainerNodeData(containerType, label, category, msg.subnet_kind),
+              data: buildContainerNodeData(containerType, label, category, parsed.subnet_kind),
             }
           : {
               id, type: "service", position,

--- a/frontend/lib/useDiagramState.ts
+++ b/frontend/lib/useDiagramState.ts
@@ -7,7 +7,7 @@ import { buildContainerNodeData } from "@/lib/containerNodeData";
 import { applyGraphDiff, GraphMutationPayload } from "@/lib/graphDiff";
 import { applyDiagramNodeChanges } from "@/lib/diagramPresentationState";
 import { clearManualPositionOverrides, type ManualPositionOverrides } from "@/lib/manualNodePositions";
-import { classifyNodeEvent, parseDiagramEvent, type AddNodeEvent } from "@/lib/diagramEventBuffer";
+import { classifyNodeEvent, parseDiagramEvent, createEventBuffer, bufferDeferredEvent, drainDeferredEvents, type EventBuffer, type AddNodeEvent } from "@/lib/diagramEventBuffer";
 
 function normalizeNode(node: Node): Node {
   const id = String(node.id ?? "");
@@ -78,6 +78,7 @@ export function useDiagramState() {
   const nodesRef = useRef<Node[]>([]);
   const edgesRef = useRef<Edge[]>([]);
   const manualPositionOverridesRef = useRef<ManualPositionOverrides>(clearManualPositionOverrides());
+  const eventBufferRef = useRef<EventBuffer>(createEventBuffer());
   const nodes = useMemo(
     () => applyDiagramNodeChanges(canonicalNodes, [], manualPositionOverrides).renderedNodes,
     [canonicalNodes, manualPositionOverrides]
@@ -113,55 +114,89 @@ export function useDiagramState() {
     setManualPositionOverrides(cleared);
     nodesRef.current = [];
     edgesRef.current = [];
+    eventBufferRef.current = createEventBuffer();
   }, []);
+
+  const applyAddNode = useCallback((parsed: AddNodeEvent, existingNodes: Node[]): Node[] => {
+    const id = parsed.id;
+    const label = parsed.label;
+    const category = parsed.category;
+    const isContainer = parsed.node_type === "container";
+    const containerType = normalizeContainerType(parsed.container_type);
+    const parentId = parsed.parent_id;
+    const position = typeof parsed.position === "object" && parsed.position !== null
+      ? {
+          x: Number.isFinite((parsed.position as { x?: unknown }).x) ? Number((parsed.position as { x?: number }).x) : 0,
+          y: Number.isFinite((parsed.position as { y?: unknown }).y) ? Number((parsed.position as { y?: number }).y) : 0,
+        }
+      : { x: 0, y: 0 };
+    const style = typeof parsed.style === "object" && parsed.style !== null ? parsed.style as Node["style"] : undefined;
+
+    if (existingNodes.find((n) => n.id === id)) return existingNodes;
+
+    const node: Node = isContainer
+      ? {
+          id, type: "container", position,
+          ...(parentId ? { parentId, extent: "parent" as const } : {}),
+          style: { ...defaultContainerSize(containerType), ...style },
+          data: buildContainerNodeData(containerType, label, category, parsed.subnet_kind),
+        }
+      : {
+          id, type: "service", position,
+          ...(parentId ? { parentId, extent: "parent" as const } : {}),
+          data: { label, category, nodeType: deriveNodeType(id) },
+        };
+    return sortNodesForRender([...existingNodes, node]);
+  }, []);
+
+  const processNodeEvent = useCallback((parsed: AddNodeEvent) => {
+    const classResult = classifyNodeEvent(parsed, {
+      hasNode: (id: string) => nodesRef.current.some((n) => n.id === id),
+    });
+
+    if (classResult.action === "skip_duplicate") return;
+
+    if (classResult.action === "defer") {
+      eventBufferRef.current = bufferDeferredEvent(eventBufferRef.current, parsed, classResult.missingParentId);
+      return;
+    }
+
+    setCanonicalNodes((prev) => {
+      let next = applyAddNode(parsed, prev);
+
+      const pending: AddNodeEvent[] = [];
+      const { events: drained, buffer: nextBuffer } = drainDeferredEvents(eventBufferRef.current, parsed.id);
+      eventBufferRef.current = nextBuffer;
+      pending.push(...drained);
+
+      let index = 0;
+      while (index < pending.length) {
+        const event = pending[index];
+        const innerAction = classifyNodeEvent(event, {
+          hasNode: (id: string) => next.some((n) => n.id === id),
+        });
+        if (innerAction.action === "apply") {
+          next = applyAddNode(event, next);
+          const { events: innerDrained, buffer: innerBuffer } = drainDeferredEvents(eventBufferRef.current, event.id);
+          eventBufferRef.current = innerBuffer;
+          pending.push(...innerDrained);
+        }
+        index += 1;
+      }
+
+      nodesRef.current = next;
+      const cleared = clearManualPositionOverrides();
+      manualPositionOverridesRef.current = cleared;
+      setManualPositionOverrides(cleared);
+      return next;
+    });
+  }, [applyAddNode]);
 
   const handleDiagramEvent = useCallback((msg: Record<string, unknown>) => {
     if (msg.action === "add_node") {
       const parsed = parseDiagramEvent(msg);
       if (!parsed || parsed.type !== "add_node") return;
-
-      const action = classifyNodeEvent(parsed, {
-        hasNode: (id: string) => nodesRef.current.some((n) => n.id === id),
-      });
-
-      if (action.action === "skip_duplicate") return;
-      if (action.action === "defer") return;
-
-      const id = parsed.id;
-      const label = parsed.label;
-      const category = parsed.category;
-      const isContainer = parsed.node_type === "container";
-      const containerType = normalizeContainerType(parsed.container_type);
-      const parentId = parsed.parent_id;
-      const position = typeof parsed.position === "object" && parsed.position !== null
-        ? {
-            x: Number.isFinite((parsed.position as { x?: unknown }).x) ? Number((parsed.position as { x?: number }).x) : 0,
-            y: Number.isFinite((parsed.position as { y?: unknown }).y) ? Number((parsed.position as { y?: number }).y) : 0,
-          }
-        : { x: 0, y: 0 };
-      const style = typeof parsed.style === "object" && parsed.style !== null ? parsed.style as Node["style"] : undefined;
-
-      setCanonicalNodes((prev) => {
-        if (prev.find((n) => n.id === id)) return prev;
-        const node: Node = isContainer
-          ? {
-              id, type: "container", position,
-              ...(parentId ? { parentId, extent: "parent" as const } : {}),
-              style: { ...defaultContainerSize(containerType), ...style },
-              data: buildContainerNodeData(containerType, label, category, parsed.subnet_kind),
-            }
-          : {
-              id, type: "service", position,
-              ...(parentId ? { parentId, extent: "parent" as const } : {}),
-              data: { label, category, nodeType: deriveNodeType(id) },
-            };
-        const next = sortNodesForRender([...prev, node]);
-        nodesRef.current = next;
-        const cleared = clearManualPositionOverrides();
-        manualPositionOverridesRef.current = cleared;
-        setManualPositionOverrides(cleared);
-        return next;
-      });
+      processNodeEvent(parsed);
     }
 
     if (msg.action === "add_edge") {
@@ -179,7 +214,7 @@ export function useDiagramState() {
         return next;
       });
     }
-  }, []);
+  }, [processNodeEvent]);
 
   const applyLayout = useCallback(() => {
     setCanonicalNodes((prev) => {


### PR DESCRIPTION
## Summary

- Update architect prompt to support `region` containers and document `region -> vpc -> az -> subnet -> services` hierarchy
- Add frontend event validation that defers add_node events when their parent doesn't exist yet, preventing React Flow crashes
- Add out-of-order event buffering with deferred replay so child nodes applied after their parent arrive are handled correctly
- Add tests verifying region container persistence and snapshot replay in the backend

## Changes

### Backend
- `backend/agents/architect.py` — Added region container type example and multi-region ordering rules to system prompt
- `backend/tests/agents/test_architect.py` — 2 new tests for region container contract and multi-region streaming
- `backend/tests/test_generation_service.py` — 2 new tests for region container persistence and snapshot replay

### Frontend
- `frontend/lib/diagramEventBuffer.ts` — New pure module with event parsing, parent validation (`classifyNodeEvent`), and out-of-order buffering (`EventBuffer`)
- `frontend/lib/__tests__/diagramEventBuffer.test.ts` — 15 tests covering parsing, classification, and buffering
- `frontend/lib/useDiagramState.ts` — Refactored `handleDiagramEvent` to use classification + buffered replay instead of blindly applying `parentId`

## Fixes

Closes #189 — the "Parent node eu_central_1 not found" crash during multi-region generation.

## Test Results

- Backend: 291 collected, 0 new failures (6 pre-existing in `test_ws_handler.py` mutation formatting tests)
- Frontend: 196 collected, 0 new failures (1 pre-existing in `templates.test.ts`)