### PR TITLE
feat: right-panel observability for initial architecture generation

### DIFF
--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -1535,6 +1535,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
                 )
             else:
                 runtime.persistence.cost_estimate = None
+                await runtime.update_generation_agent("cost_analyst", "completed")
                 await runtime.emit_pipeline_event(
                     "cost_analyst",
                     "skipped",
@@ -1593,7 +1594,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             await runtime.send_text(json.dumps({"type": "diagram_reset"}))
         else:
             await runtime.set_generation_state(status="running", stage="requirements")
-            await runtime.init_generation_observability()
+            runtime.init_generation_observability()
             await runtime.update_generation_agent("requirements", "running")
             await runtime.emit_pipeline_event("requirements", "started", "info", "Processing questionnaire answers")
             await runtime.send_text(json.dumps({"type": "status", "message": "Analyzing your requirements..."}))

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -754,6 +754,7 @@ class GenerationRuntime:
         self.broadcaster = broadcaster
         self.llm_creds = llm_creds
         self.client_ip = client_ip
+        self._generation_observability: list[dict[str, Any]] | None = None
 
     async def _broadcast(self, payload: dict[str, Any]) -> None:
         enriched = {
@@ -975,11 +976,53 @@ class GenerationRuntime:
             },
         )
 
+    def init_generation_observability(self) -> None:
+        self._generation_observability = _init_generation_observability()
+
+    async def update_generation_agent(
+        self,
+        agent_name: str,
+        status: str,
+        *,
+        error: str | None = None,
+    ) -> None:
+        if not self._generation_observability:
+            return
+        _update_generation_agent(
+            self._generation_observability,
+            agent_name,
+            status,
+            error=error,
+        )
+        await self.broadcast_generation_observability()
+
+    def get_generation_observability_snapshot(self) -> list[dict[str, Any]] | None:
+        if not self._generation_observability:
+            return None
+        return copy.deepcopy(self._generation_observability)
+
+    async def broadcast_generation_observability(self) -> None:
+        if not self._generation_observability:
+            return
+        payload = {
+            "type": "generation_agent_update",
+            "mode": "initial_generation",
+            "agents": self._generation_observability,
+        }
+        await self._broadcast(payload)
+
 
 _BROADCASTER = ProjectBroadcaster()
 _RUNNING_TASKS: dict[str, asyncio.Task[None]] = {}
 _RUNTIMES: dict[str, GenerationRuntime] = {}
 _TASKS_LOCK = asyncio.Lock()
+
+
+def get_generation_observability(project_id: str) -> list[dict[str, Any]] | None:
+    runtime = _RUNTIMES.get(project_id)
+    if not runtime:
+        return None
+    return runtime.get_generation_observability_snapshot()
 
 _RERUN_AGENT_ORDER = ("coder", "description")
 
@@ -1266,6 +1309,138 @@ async def _prepare_existing_project_for_run(
     return refreshed
 
 
+_AGENT_OBSERVABILITY_SCHEMA: dict[str, dict[str, Any]] = {
+    "requirements": {
+        "label": "Requirements",
+        "blocked_by": [],
+    },
+    "architect": {
+        "label": "Architect",
+        "blocked_by": ["requirements"],
+    },
+    "cost_analyst": {
+        "label": "Cost analysis",
+        "blocked_by": ["architect"],
+    },
+}
+
+_AGENT_HISTORY: dict[str, dict[str, list[str]]] = {
+    "requirements": {
+        "running": ["Reading your app description", "Inferring the AWS services you likely need"],
+        "completed": ["Requirements extracted"],
+    },
+    "architect": {
+        "running": ["Designing your AWS architecture", "Laying out networking and compute components"],
+        "completed": ["Architecture draft complete"],
+    },
+    "cost_analyst": {
+        "running": ["Estimating monthly AWS cost", "Reviewing the architecture for major cost drivers"],
+        "completed": ["Cost estimate ready"],
+    },
+}
+
+_AGENT_RUNNING_SUMMARY: dict[str, str] = {
+    "requirements": "Turning your app description into infrastructure requirements",
+    "architect": "Designing your AWS architecture",
+    "cost_analyst": "Estimating monthly AWS cost",
+}
+
+_AGENT_COMPLETED_SUMMARY: dict[str, str] = {
+    "requirements": "Requirements ready",
+    "architect": "Architecture ready for cost review",
+    "cost_analyst": "Cost estimate ready",
+}
+
+_MAX_HISTORY: int = 3
+
+
+def _init_generation_observability() -> list[dict[str, Any]]:
+    agents: list[dict[str, Any]] = []
+    for agent_name, schema in _AGENT_OBSERVABILITY_SCHEMA.items():
+        blocked_by = list(schema["blocked_by"])
+        agents.append({
+            "agent": agent_name,
+            "label": schema["label"],
+            "status": "blocked" if blocked_by else "queued",
+            "summary": (
+                f"Waiting for {blocked_by[0].replace('_', ' ')}"
+                if blocked_by
+                else "Ready to start"
+            ),
+            "detail": None,
+            "blocked_by": blocked_by,
+            "started_at": None,
+            "completed_at": None,
+            "elapsed_ms": None,
+            "progress_text": None,
+            "history": [],
+            "error": None,
+        })
+    return agents
+
+
+def _update_generation_agent(
+    agents: list[dict[str, Any]],
+    agent_name: str,
+    status: str,
+    *,
+    now_utc: str | None = None,
+    error: str | None = None,
+) -> None:
+    for agent in agents:
+        if agent["agent"] != agent_name:
+            continue
+
+        agent["status"] = status
+
+        if status == "running":
+            agent["summary"] = _AGENT_RUNNING_SUMMARY.get(agent_name, "")
+            agent["started_at"] = now_utc or _now_utc_iso()
+            agent["completed_at"] = None
+            agent["error"] = None
+            milestones = _AGENT_HISTORY.get(agent_name, {}).get("running", [])
+            agent["history"] = list(milestones[:_MAX_HISTORY])
+            agent["progress_text"] = milestones[0] if milestones else None
+
+        elif status == "completed":
+            agent["summary"] = _AGENT_COMPLETED_SUMMARY.get(agent_name, "")
+            agent["completed_at"] = now_utc or _now_utc_iso()
+            agent["progress_text"] = None
+            if agent["started_at"]:
+                try:
+                    started = datetime.fromisoformat(agent["started_at"])
+                    completed = datetime.fromisoformat(agent["completed_at"])
+                    agent["elapsed_ms"] = int((completed - started).total_seconds() * 1000)
+                except (ValueError, TypeError):
+                    pass
+            done_entries = _AGENT_HISTORY.get(agent_name, {}).get("completed", [])
+            agent["history"] = agent.get("history", [])[:_MAX_HISTORY - 1] + list(done_entries[:1])
+
+        elif status == "failed":
+            agent["summary"] = "Could not finish this step"
+            agent["completed_at"] = now_utc or _now_utc_iso()
+            agent["progress_text"] = None
+            agent["error"] = error
+            if agent["started_at"]:
+                try:
+                    started = datetime.fromisoformat(agent["started_at"])
+                    completed = datetime.fromisoformat(agent["completed_at"])
+                    agent["elapsed_ms"] = int((completed - started).total_seconds() * 1000)
+                except (ValueError, TypeError):
+                    pass
+
+    if status in ("completed", "failed"):
+        for agent in agents:
+            if agent_name in agent["blocked_by"]:
+                if status == "failed":
+                    agent["status"] = "blocked"
+                    agent["summary"] = f"Blocked because {agent_name.replace('_', ' ')} stopped"
+                else:
+                    agent["status"] = "queued"
+                    agent["summary"] = "Ready to start"
+                    agent["blocked_by"] = []
+
+
 async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
     user_id = runtime.user_id
     project_id = runtime.project_id
@@ -1298,6 +1473,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             await runtime.send_text(
                 json.dumps({"type": "status", "message": "Designing architecture..."})
             )
+            await runtime.update_generation_agent("architect", "running")
             await runtime.emit_pipeline_event("architect", "started", "info", "architect started")
             await runtime.set_generation_state(status="running", stage="architect")
 
@@ -1307,6 +1483,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
                 await runtime.emit_pipeline_event("architect", "failed", "error", "architect failed", {"error": str(error)})
                 raise
 
+            await runtime.update_generation_agent("architect", "completed")
             await runtime.emit_pipeline_event("architect", "completed", "info", "architect completed")
             diagram_nodes = list(runtime.persistence.nodes)
             logger.info("Architect complete project_id=%s trace_id=%s nodes=%d", project_id, runtime.trace_id, len(diagram_nodes))
@@ -1328,6 +1505,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
                     )
                 raise RuntimeError("Architect returned an empty architecture output.")
 
+            await runtime.update_generation_agent("cost_analyst", "running")
             await runtime.emit_pipeline_event("cost_analyst", "started", "info", "cost analyst started")
             await runtime.set_generation_state(status="running", stage="cost_analyst")
 
@@ -1343,6 +1521,7 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             if isinstance(cost_estimate, dict):
                 runtime.persistence.cost_estimate = cost_estimate
                 await runtime.send_text(json.dumps({"type": "cost_estimate", **cost_estimate}))
+                await runtime.update_generation_agent("cost_analyst", "completed")
                 await runtime.emit_pipeline_event(
                     "cost_analyst",
                     "completed",
@@ -1414,10 +1593,13 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             await runtime.send_text(json.dumps({"type": "diagram_reset"}))
         else:
             await runtime.set_generation_state(status="running", stage="requirements")
+            await runtime.init_generation_observability()
+            await runtime.update_generation_agent("requirements", "running")
             await runtime.emit_pipeline_event("requirements", "started", "info", "Processing questionnaire answers")
             await runtime.send_text(json.dumps({"type": "status", "message": "Analyzing your requirements..."}))
             await emit_log(runtime, "requirements", "Processing questionnaire answers...", start_time)
 
+            await runtime.update_generation_agent("requirements", "completed")
             requirements = await _generate_requirements_with_retry(
                 runtime,
                 answers,
@@ -1531,6 +1713,13 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             project_id, runtime.trace_id, str(error),
             exc_info=not isinstance(error, BaseExceptionGroup),
         )
+        if runtime._generation_observability:
+            for agent in runtime._generation_observability:
+                if agent.get("status") == "running":
+                    await runtime.update_generation_agent(
+                        agent["agent"], "failed", error=str(error),
+                    )
+                    break
         error_code = "pipeline_failed"
         budget_recovery_metadata: dict[str, Any] | None = None
         if isinstance(error, BudgetCapUnmetError):

--- a/backend/ws_handler.py
+++ b/backend/ws_handler.py
@@ -155,36 +155,37 @@ async def _send_generation_snapshot(websocket: WebSocket, row: dict[str, Any]) -
     if isinstance(project_id, str):
         generation_agents = get_generation_observability(project_id)
 
-    return await _safe_send_json(
-        websocket,
-        {
-            "type": "generation_snapshot",
-            "project_id": project_id,
-            "project_mode": row.get("project_mode"),
-            "nodes": row.get("nodes") if isinstance(row.get("nodes"), list) else [],
-            "edges": row.get("edges") if isinstance(row.get("edges"), list) else [],
-            "terraform_files": row.get("terraform_files") if isinstance(row.get("terraform_files"), list) else [],
-            "cost_estimate": row.get("cost_estimate") if isinstance(row.get("cost_estimate"), dict) else None,
-            "chat_history": row.get("chat_history") if isinstance(row.get("chat_history"), list) else [],
-            "generation_status": row.get("generation_status"),
-            "generation_stage": row.get("generation_stage"),
-            "generation_error": row.get("generation_error"),
-            "generation_trace_id": row.get("generation_trace_id"),
-            "generation_started_at": row.get("generation_started_at"),
-            "generation_completed_at": row.get("generation_completed_at"),
-            "last_event_at": row.get("last_event_at"),
-            "setup_pdf_status": row.get("setup_pdf_status"),
-            "setup_pdf_progress": row.get("setup_pdf_progress"),
-            "setup_pdf_error": row.get("setup_pdf_error"),
-            "setup_pdf_generated_at": row.get("setup_pdf_generated_at"),
-            "setup_pdf_source_revision": row.get("setup_pdf_source_revision"),
-            "terraform_outdated": terraform_outdated,
-            "setup_pdf_outdated": setup_pdf_outdated,
-            "terraform_generated_at": terraform_time,
-            "architecture_modified_at": arch_time,
-            "generation_agents": generation_agents,
-        },
-    )
+    snapshot_payload: dict[str, Any] = {
+        "type": "generation_snapshot",
+        "project_id": project_id,
+        "project_mode": row.get("project_mode"),
+        "nodes": row.get("nodes") if isinstance(row.get("nodes"), list) else [],
+        "edges": row.get("edges") if isinstance(row.get("edges"), list) else [],
+        "terraform_files": row.get("terraform_files") if isinstance(row.get("terraform_files"), list) else [],
+        "cost_estimate": row.get("cost_estimate") if isinstance(row.get("cost_estimate"), dict) else None,
+        "chat_history": row.get("chat_history") if isinstance(row.get("chat_history"), list) else [],
+        "generation_status": row.get("generation_status"),
+        "generation_stage": row.get("generation_stage"),
+        "generation_error": row.get("generation_error"),
+        "generation_trace_id": row.get("generation_trace_id"),
+        "generation_started_at": row.get("generation_started_at"),
+        "generation_completed_at": row.get("generation_completed_at"),
+        "last_event_at": row.get("last_event_at"),
+        "setup_pdf_status": row.get("setup_pdf_status"),
+        "setup_pdf_progress": row.get("setup_pdf_progress"),
+        "setup_pdf_error": row.get("setup_pdf_error"),
+        "setup_pdf_generated_at": row.get("setup_pdf_generated_at"),
+        "setup_pdf_source_revision": row.get("setup_pdf_source_revision"),
+        "terraform_outdated": terraform_outdated,
+        "setup_pdf_outdated": setup_pdf_outdated,
+        "terraform_generated_at": terraform_time,
+        "architecture_modified_at": arch_time,
+    }
+
+    if generation_agents is not None:
+        snapshot_payload["generation_agents"] = generation_agents
+
+    return await _safe_send_json(websocket, snapshot_payload)
 
 
 def _apply_canvas_edit(

--- a/backend/ws_handler.py
+++ b/backend/ws_handler.py
@@ -16,6 +16,7 @@ from generation_service import (
     broadcast_project_event,
     GenerationStartError,
     append_chat_history,
+    get_generation_observability,
     rerun_project_agents_for_user,
     start_generation_for_user,
     subscribe_websocket,
@@ -149,11 +150,16 @@ async def _send_generation_snapshot(websocket: WebSocket, row: dict[str, Any]) -
 
     setup_pdf_outdated = row.get("setup_pdf_status") == "outdated"
 
+    project_id = row.get("id")
+    generation_agents = None
+    if isinstance(project_id, str):
+        generation_agents = get_generation_observability(project_id)
+
     return await _safe_send_json(
         websocket,
         {
             "type": "generation_snapshot",
-            "project_id": row.get("id"),
+            "project_id": project_id,
             "project_mode": row.get("project_mode"),
             "nodes": row.get("nodes") if isinstance(row.get("nodes"), list) else [],
             "edges": row.get("edges") if isinstance(row.get("edges"), list) else [],
@@ -176,6 +182,7 @@ async def _send_generation_snapshot(websocket: WebSocket, row: dict[str, Any]) -
             "setup_pdf_outdated": setup_pdf_outdated,
             "terraform_generated_at": terraform_time,
             "architecture_modified_at": arch_time,
+            "generation_agents": generation_agents,
         },
     )
 
@@ -689,6 +696,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
       - status:             { type, project_id, trace_id, message }
       - agent_log:          { type, project_id, trace_id, agent, message, elapsed, duration_ms, details? }
       - diagram_event:      { type, project_id, trace_id, action, ... }
+      - generation_agent_update: { type, project_id, trace_id, mode, agents[] }
       - terraform_file:     { type, project_id, trace_id, filename, content, description }
       - arch_description:   { type, project_id, trace_id, sections }
       - cost_estimate:      { type, project_id, region, monthly_total, items[] }

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -130,6 +130,41 @@ The Architect streams diagram events. Each event maps directly to a mutation of 
 - `container_type?: "region" | "vpc" | "az" | "subnet"`
 - `subnet_kind?: "public" | "private"` when `container_type === "subnet"`
 
+### Generation Observability (via WebSocket)
+
+During initial architecture generation, the backend emits structured per-agent state via `generation_agent_update` messages.
+
+**Agent state shape:**
+```typescript
+{
+  agent: string             // "requirements" | "architect" | "cost_analyst"
+  label: string             // Human-readable name
+  status: "queued" | "running" | "completed" | "failed" | "blocked"
+  summary: string           // User-facing description
+  detail: string | null     // Optional additional context
+  blocked_by: string[]      // Upstream agent dependencies
+  started_at: string | null // ISO 8601 timestamp
+  completed_at: string | null
+  elapsed_ms: number | null
+  progress_text: string | null  // Current activity text
+  history: string[]         // Recent milestones, capped to 3
+  error: string | null      // Error message if failed
+}
+```
+
+**Dependency chain:** `requirements` → `architect` → `cost_analyst`
+
+**Failure propagation:**
+- If an agent fails, downstream agents transition to `blocked`
+- When an upstream completes, downstream agents transition from `blocked` to `queued`
+
+**Lifecycle (only for initial `start_generation` flows):**
+1. Requirements starts as `queued`, then `running`, then `completed`
+2. Architect starts as `blocked`, becomes `queued` when Requirements completes, then `running`, then `completed`
+3. Cost analysis starts as `blocked`, becomes `queued` when Architect completes, then `running`, then `completed`
+
+**Transience:** This state is in-memory only during active generation. It is not persisted to the database long-term. It is included in `generation_snapshot` while a generation is active for reconnect support.
+
 ### Canvas → Terraform (via WebSocket)
 
 When approved architecture changes update the graph, the resulting current diagram state (nodes + edges) is the source for regeneration. There is no surgical diff — the Coder agent regenerates everything from scratch.

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -121,9 +121,9 @@ During initial architecture generation, the right panel auto-opens into a dedica
 - Mini-history of recent milestones
 
 **Behavior:**
-- Right panel auto-opens to the `generation` tab on `generation_started`
-- If user opens Templates, My Designs, or Output during the run, the panel stops auto-focusing
-- Generation tab persists until user navigates away
+- Right panel auto-opens to the `generation` tab when `isGenerating` transitions from false to true (i.e., on `generation_started`)
+- If user opens Templates, My Designs, or Output while generation is running, auto-opening is suppressed for the remainder of that run
+- Suppression resets when the current generation completes or fails
 - Completed state remains visible until the user opens another tab
 - This view is only shown for initial `start_generation` flows; not for chat edits, terraform generation, or reruns
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -99,6 +99,34 @@ Users start generation from the main workspace using the **Describe your app** a
 - Chat is the only way to add, remove, rename, or otherwise re-architect the diagram
 - Approved architectural changes still update the persisted project graph used for Terraform generation
 
+### 2.3 Right Panel — Generation Observability
+
+**Component:** `components/GenerationObservabilityPanel.tsx`
+
+During initial architecture generation, the right panel auto-opens into a dedicated "Architecture Generation" view.
+
+**Displayed agents:**
+| Agent | Label | Dependency |
+|-------|-------|-----------|
+| `requirements` | Requirements | None |
+| `architect` | Architect | Requires `requirements` |
+| `cost_analyst` | Cost analysis | Requires `architect` |
+
+**Card contents per agent:**
+- Role icon (clipboard, pen tool, dollar sign)
+- Status icon (queued/running/completed/failed/blocked)
+- User-facing summary line
+- Optional progress text
+- Elapsed time on completion
+- Mini-history of recent milestones
+
+**Behavior:**
+- Right panel auto-opens to the `generation` tab on `generation_started`
+- If user opens Templates, My Designs, or Output during the run, the panel stops auto-focusing
+- Generation tab persists until user navigates away
+- Completed state remains visible until the user opens another tab
+- This view is only shown for initial `start_generation` flows; not for chat edits, terraform generation, or reruns
+
 ---
 
 ## 3. WebSocket Protocol
@@ -120,9 +148,10 @@ Users start generation from the main workspace using the **Describe your app** a
 | Type | Payload | Description |
 |------|---------|-------------|
 | `project_ready` | `{ project_id, share_slug }` | New project created; frontend should update URL |
-| `generation_snapshot` | `{ project_id, project_mode, generation_status, generation_stage, generation_error, generation_trace_id, generation_started_at, generation_completed_at, last_event_at, terraform_outdated, setup_pdf_outdated, terraform_generated_at, architecture_modified_at }` | Snapshot for subscribe/reconnect; includes outdated flags for terraform and PDF |
+| `generation_snapshot` | `{ project_id, project_mode, generation_status, generation_stage, generation_error, generation_trace_id, generation_started_at, generation_completed_at, last_event_at, terraform_outdated, setup_pdf_outdated, terraform_generated_at, architecture_modified_at, generation_agents? }` | Snapshot for subscribe/reconnect; includes outdated flags for terraform and PDF; `generation_agents` is present while initial generation is active |
 | `diagram_event` | `{ action: "add_node"\|"add_edge", id, label, category, node_type?, container_type?, subnet_kind?, parent_id?, position?, style?, project_id, trace_id }` | Live canvas update; consumed incrementally |
 | `agent_log` | `{ agent, message, elapsed, duration_ms, trace_id?, details?, project_id? }` | Agent lifecycle/progress breadcrumb shown in activity feed and correlated backend logs |
+| `generation_agent_update` | `{ mode: "initial_generation", agents: [{ agent, label, status, summary, detail, blocked_by, started_at, completed_at, elapsed_ms, progress_text, history, error }] }` | Structured per-agent observability state for the generation panel; emitted only during initial `start_generation` flows |
 | `chat_reply` | `{ message, project_id, execution_mode?, plan_ready?: bool, plan_meta?: {...} }` | Assistant message for Q&A/refactor loop; `plan_ready: true` marks an approvable architecture proposal |
 | `chat_reply_delta` | `{ delta, project_id }` | Streaming chunk for assistant message |
 | `chat_reply_done` | `{ message, project_id, execution_mode?, plan_ready?: bool, plan_meta?: {...} }` | Final assembled message after streaming; for node_patch plans, plan_meta includes detailed changes (nodes_added, nodes_edited, nodes_deleted, edges_added, edges_deleted, reasoning) |

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -141,9 +141,10 @@ function WorkspaceContent() {
           open={workspace.rightPanelOpen}
           tab={workspace.rightPanelTab}
           onClose={workspace.closeRightPanel}
+          generationAgents={pipeline.generationAgents}
+          isGenerating={pipeline.isGenerating}
           terraformFiles={pipeline.terraformFiles}
           archDescription={pipeline.archDescription}
-          isGenerating={pipeline.isGenerating}
           terraformProgress={pipeline.terraformProgress}
           terraformOutdated={pipeline.terraformOutdated}
           onRegenerateTerraform={pipeline.generateTerraform}

--- a/frontend/components/GenerationObservabilityPanel.tsx
+++ b/frontend/components/GenerationObservabilityPanel.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import AgentStepCard from "@/components/GenerationObservabilityPanel/AgentStepCard";
+import type { GenerationAgentState } from "@/lib/generationObservability";
+
+type Props = {
+  agents: GenerationAgentState[] | null;
+  isGenerating: boolean;
+};
+
+export default function GenerationObservabilityPanel({ agents, isGenerating }: Props) {
+  if (!agents) {
+    if (isGenerating) {
+      return (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-gray-500">
+            <RefreshCw size={20} className="animate-spin" />
+            <span className="text-xs">Starting generation...</span>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <span className="text-xs text-gray-500">No generation data.</span>
+      </div>
+    );
+  }
+
+  const allComplete = agents.every(
+    (a) => a.status === "completed" || a.status === "failed" || a.status === "blocked",
+  );
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4 space-y-1">
+      <p className="text-xs text-gray-500 mb-4">
+        {allComplete
+          ? "Your architecture has been generated."
+          : "Three AI steps are building your AWS architecture."}
+      </p>
+      <div className="relative space-y-1">
+        {agents.length > 1 && (
+          <div className="absolute left-[19px] top-8 bottom-8 w-px bg-gray-800" />
+        )}
+        {agents.map((agent, index) => (
+          <AgentStepCard
+            key={agent.agent}
+            agent={agent}
+            isFirst={index === 0}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/GenerationObservabilityPanel.tsx
+++ b/frontend/components/GenerationObservabilityPanel.tsx
@@ -43,11 +43,10 @@ export default function GenerationObservabilityPanel({ agents, isGenerating }: P
         {agents.length > 1 && (
           <div className="absolute left-[19px] top-8 bottom-8 w-px bg-gray-800" />
         )}
-        {agents.map((agent, index) => (
+        {agents.map((agent) => (
           <AgentStepCard
             key={agent.agent}
             agent={agent}
-            isFirst={index === 0}
           />
         ))}
       </div>

--- a/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
+++ b/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  ClipboardList,
+  PenTool,
+  DollarSign,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  Clock,
+  CircleDot,
+  Ban,
+} from "lucide-react";
+import AgentStepMiniHistory from "./AgentStepMiniHistory";
+import type { GenerationAgentState } from "@/lib/generationObservability";
+
+type Props = {
+  agent: GenerationAgentState;
+  isFirst: boolean;
+};
+
+const ROLE_ICONS: Record<string, typeof ClipboardList> = {
+  requirements: ClipboardList,
+  architect: PenTool,
+  cost_analyst: DollarSign,
+};
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "running":
+      return <Loader2 size={14} className="text-blue-400 animate-spin" />;
+    case "completed":
+      return <CheckCircle2 size={14} className="text-green-400" />;
+    case "failed":
+      return <AlertCircle size={14} className="text-red-400" />;
+    case "blocked":
+      return <Ban size={14} className="text-gray-600" />;
+    case "queued":
+    default:
+      return <Clock size={14} className="text-gray-500" />;
+  }
+}
+
+function formatElapsed(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+export default function AgentStepCard({ agent, isFirst }: Props) {
+  const RoleIcon = ROLE_ICONS[agent.agent] ?? CircleDot;
+  const isMuted = agent.status === "blocked" || agent.status === "queued";
+  const isActive = agent.status === "running";
+
+  return (
+    <div
+      className={`relative flex gap-3 p-3 rounded-lg transition-colors ${
+        isActive
+          ? "bg-gray-800/60 border border-blue-500/20"
+          : isMuted
+            ? "opacity-60"
+            : "border border-transparent"
+      }`}
+    >
+      <div className="flex flex-col items-center pt-0.5 gap-1 relative z-10">
+        <div
+          className={`w-8 h-8 rounded-full flex items-center justify-center ${
+            agent.status === "completed"
+              ? "bg-green-500/10"
+              : agent.status === "failed"
+                ? "bg-red-500/10"
+                : isActive
+                  ? "bg-blue-500/10"
+                  : "bg-gray-800"
+          }`}
+        >
+          <RoleIcon
+            size={16}
+            className={
+              agent.status === "completed"
+                ? "text-green-400"
+                : agent.status === "failed"
+                  ? "text-red-400"
+                  : isActive
+                    ? "text-blue-400"
+                    : "text-gray-500"
+            }
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-xs font-semibold text-gray-200">{agent.label}</span>
+          <StatusIcon status={agent.status} />
+        </div>
+
+        <p className={`text-xs ${isMuted ? "text-gray-600" : "text-gray-400"}`}>
+          {agent.summary}
+        </p>
+
+        {agent.progress_text && agent.status === "running" && (
+          <p className="text-[11px] text-gray-500 mt-1">{agent.progress_text}</p>
+        )}
+
+        {agent.elapsed_ms != null && agent.status !== "running" && (
+          <p className="text-[10px] text-gray-600 mt-1 font-mono">
+            {formatElapsed(agent.elapsed_ms)}
+          </p>
+        )}
+
+        {agent.history.length > 0 && (
+          <AgentStepMiniHistory items={agent.history} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
+++ b/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
@@ -16,7 +16,6 @@ import type { GenerationAgentState } from "@/lib/generationObservability";
 
 type Props = {
   agent: GenerationAgentState;
-  isFirst: boolean;
 };
 
 const ROLE_ICONS: Record<string, typeof ClipboardList> = {
@@ -47,7 +46,7 @@ function formatElapsed(ms: number): string {
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
-export default function AgentStepCard({ agent, isFirst }: Props) {
+export default function AgentStepCard({ agent }: Props) {
   const RoleIcon = ROLE_ICONS[agent.agent] ?? CircleDot;
   const isMuted = agent.status === "blocked" || agent.status === "queued";
   const isActive = agent.status === "running";

--- a/frontend/components/GenerationObservabilityPanel/AgentStepMiniHistory.tsx
+++ b/frontend/components/GenerationObservabilityPanel/AgentStepMiniHistory.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export default function AgentStepMiniHistory({ items }: { items: string[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <ul className="mt-1.5 space-y-0.5">
+      {items.map((item, index) => (
+        <li
+          key={`${item}-${index}`}
+          className="flex items-start gap-1.5 text-[11px] text-gray-600"
+        >
+          <span className="mt-1 w-1 h-1 rounded-full bg-gray-700 flex-shrink-0" />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/components/RightPanel.tsx
+++ b/frontend/components/RightPanel.tsx
@@ -3,21 +3,25 @@
 import { LayoutGrid, X } from "lucide-react";
 import OutputPanel, { type TerraformFile } from "@/components/OutputPanel";
 import type { ArchDescription } from "@/components/ArchDescriptionViewer";
+import GenerationObservabilityPanel from "@/components/GenerationObservabilityPanel";
 import MyDesignsList from "@/components/RightPanel/MyDesignsList";
 import TemplatesPanel from "@/components/RightPanel/TemplatesPanel";
 import type { ProjectSummary } from "@/lib/projects";
 import type { SetupPdfState } from "@/lib/setupPdf";
 import type { TerraformProgress } from "@/components/TerraformViewer";
 import type { RightPanelTab } from "@/lib/useWorkspace";
+import type { GenerationAgentState } from "@/lib/generationObservability";
 
 interface RightPanelProps {
   open: boolean;
   tab: RightPanelTab;
   onClose: () => void;
 
+  generationAgents: GenerationAgentState[] | null;
+  isGenerating: boolean;
+
   terraformFiles: TerraformFile[];
   archDescription: ArchDescription | null;
-  isGenerating: boolean;
   terraformProgress?: TerraformProgress;
   terraformOutdated?: boolean;
   onRegenerateTerraform?: () => void;
@@ -41,9 +45,10 @@ export default function RightPanel({
   open,
   tab,
   onClose,
+  generationAgents,
+  isGenerating,
   terraformFiles,
   archDescription,
-  isGenerating,
   terraformProgress,
   terraformOutdated,
   onRegenerateTerraform,
@@ -62,7 +67,7 @@ export default function RightPanel({
   onCancelDelete,
 }: RightPanelProps) {
   const fileLabel = terraformFiles.length === 1 ? "file" : "files";
-  const tabTitle = tab === "designs" ? "My Designs" : "Templates";
+  const tabTitle = tab === "designs" ? "My Designs" : tab === "generation" ? "Architecture Generation" : "Templates";
   const isTemplatesTab = tab === "templates";
 
   return (
@@ -95,7 +100,9 @@ export default function RightPanel({
       </div>
 
       <div className="h-[calc(100%-49px)] flex flex-col">
-        {tab === "output" ? (
+        {tab === "generation" ? (
+          <GenerationObservabilityPanel agents={generationAgents} isGenerating={isGenerating} />
+        ) : tab === "output" ? (
           <OutputPanel
             terraformFiles={terraformFiles}
             archDescription={archDescription}

--- a/frontend/lib/__tests__/generationObservability.test.ts
+++ b/frontend/lib/__tests__/generationObservability.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseGenerationAgentUpdate,
+  parseGenerationAgentsFromSnapshot,
+} from "../generationObservability";
+
+describe("parseGenerationAgentUpdate", () => {
+  it("returns null for non-generation_agent_update messages", () => {
+    expect(parseGenerationAgentUpdate({ type: "diagram_event" })).toBeNull();
+    expect(parseGenerationAgentUpdate(null)).toBeNull();
+    expect(parseGenerationAgentUpdate("string")).toBeNull();
+  });
+
+  it("returns null when agents array is missing", () => {
+    expect(parseGenerationAgentUpdate({ type: "generation_agent_update" })).toBeNull();
+  });
+
+  it("normalizes valid agent entries and drops invalid ones", () => {
+    const result = parseGenerationAgentUpdate({
+      type: "generation_agent_update",
+      mode: "initial_generation",
+      agents: [
+        {
+          agent: "requirements",
+          label: "Requirements",
+          status: "running",
+          summary: "Reading your app description",
+          detail: null,
+          blocked_by: [],
+          started_at: "2026-04-11T12:00:00Z",
+          completed_at: null,
+          elapsed_ms: 1200,
+          progress_text: "Reading your app description",
+          history: ["Reading your app description", "Inferring core AWS services"],
+          error: null,
+        },
+        {
+          agent: "architect",
+          label: "Architect",
+          status: "blocked",
+          summary: "Waiting for requirements",
+          detail: null,
+          blocked_by: ["requirements"],
+          started_at: null,
+          completed_at: null,
+          elapsed_ms: null,
+          progress_text: null,
+          history: [],
+          error: null,
+        },
+        { agent: "bad", status: "unknown_status" },
+      ],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0].agent).toBe("requirements");
+    expect(result![0].status).toBe("running");
+    expect(result![1].agent).toBe("architect");
+    expect(result![1].status).toBe("blocked");
+  });
+
+  it("returns null when all agents are invalid", () => {
+    const result = parseGenerationAgentUpdate({
+      type: "generation_agent_update",
+      agents: [{ agent: "x", status: "nope" }],
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("parseGenerationAgentsFromSnapshot", () => {
+  it("returns null for non-generation_snapshot messages", () => {
+    expect(parseGenerationAgentsFromSnapshot({ type: "done" })).toBeNull();
+  });
+
+  it("returns null when generation_agents is absent", () => {
+    expect(parseGenerationAgentsFromSnapshot({ type: "generation_snapshot" })).toBeNull();
+  });
+
+  it("parses agents from snapshot", () => {
+    const result = parseGenerationAgentsFromSnapshot({
+      type: "generation_snapshot",
+      generation_agents: [
+        {
+          agent: "cost_analyst",
+          label: "Cost analysis",
+          status: "completed",
+          summary: "Cost estimate ready",
+          detail: null,
+          blocked_by: [],
+          started_at: "2026-04-11T12:00:00Z",
+          completed_at: "2026-04-11T12:00:05Z",
+          elapsed_ms: 5000,
+          progress_text: null,
+          history: ["Cost estimate ready"],
+          error: null,
+        },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].agent).toBe("cost_analyst");
+    expect(result![0].status).toBe("completed");
+    expect(result![0].elapsed_ms).toBe(5000);
+  });
+});

--- a/frontend/lib/generationObservability.ts
+++ b/frontend/lib/generationObservability.ts
@@ -1,0 +1,92 @@
+export type GenerationAgentStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "blocked";
+
+export interface GenerationAgentState {
+  agent: string;
+  label: string;
+  status: GenerationAgentStatus;
+  summary: string;
+  detail: string | null;
+  blocked_by: string[];
+  started_at: string | null;
+  completed_at: string | null;
+  elapsed_ms: number | null;
+  progress_text: string | null;
+  history: string[];
+  error: string | null;
+}
+
+const VALID_STATUSES: ReadonlySet<string> = new Set([
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "blocked",
+]);
+
+function isGenerationAgentStatus(value: unknown): value is GenerationAgentStatus {
+  return typeof value === "string" && VALID_STATUSES.has(value);
+}
+
+function normalizeAgent(raw: unknown): GenerationAgentState | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.agent !== "string" || !obj.agent) return null;
+  if (!isGenerationAgentStatus(obj.status)) return null;
+
+  const history = Array.isArray(obj.history)
+    ? obj.history.filter((item: unknown): item is string => typeof item === "string")
+    : [];
+
+  return {
+    agent: obj.agent,
+    label: typeof obj.label === "string" && obj.label ? obj.label : obj.agent,
+    status: obj.status,
+    summary: typeof obj.summary === "string" ? obj.summary : "",
+    detail: typeof obj.detail === "string" ? obj.detail : null,
+    blocked_by: Array.isArray(obj.blocked_by)
+      ? obj.blocked_by.filter((item: unknown): item is string => typeof item === "string")
+      : [],
+    started_at: typeof obj.started_at === "string" ? obj.started_at : null,
+    completed_at: typeof obj.completed_at === "string" ? obj.completed_at : null,
+    elapsed_ms: typeof obj.elapsed_ms === "number" ? obj.elapsed_ms : null,
+    progress_text: typeof obj.progress_text === "string" ? obj.progress_text : null,
+    history,
+    error: typeof obj.error === "string" ? obj.error : null,
+  };
+}
+
+export function parseGenerationAgentUpdate(msg: unknown): GenerationAgentState[] | null {
+  if (typeof msg !== "object" || msg === null) return null;
+  const obj = msg as Record<string, unknown>;
+  if (obj.type !== "generation_agent_update") return null;
+  if (!Array.isArray(obj.agents)) return null;
+
+  const agents: GenerationAgentState[] = [];
+  for (const item of obj.agents) {
+    const normalized = normalizeAgent(item);
+    if (normalized) agents.push(normalized);
+  }
+  return agents.length > 0 ? agents : null;
+}
+
+export function parseGenerationAgentsFromSnapshot(
+  msg: unknown,
+): GenerationAgentState[] | null {
+  if (typeof msg !== "object" || msg === null) return null;
+  const obj = msg as Record<string, unknown>;
+  if (obj.type !== "generation_snapshot") return null;
+  if (!Array.isArray(obj.generation_agents)) return null;
+
+  const agents: GenerationAgentState[] = [];
+  for (const item of obj.generation_agents) {
+    const normalized = normalizeAgent(item);
+    if (normalized) agents.push(normalized);
+  }
+  return agents.length > 0 ? agents : null;
+}

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -35,6 +35,8 @@ import {
   parseGenerationSnapshotHydration,
 } from "./budgetCapRecovery";
 import { clearTransientChatErrorStatus } from "./chatPipelineStatus";
+import type { GenerationAgentState } from "./generationObservability";
+import { parseGenerationAgentUpdate, parseGenerationAgentsFromSnapshot } from "./generationObservability";
 
 export type AgentLogEntry = {
   id: number;
@@ -277,6 +279,7 @@ export function useCanvasPipeline(
   const [streamingAssistantReply, setStreamingAssistantReply] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [agentLogs, setAgentLogs] = useState<AgentLogEntry[]>([]);
+  const [generationAgents, setGenerationAgents] = useState<GenerationAgentState[] | null>(null);
   const [generationElapsed, setGenerationElapsed] = useState<number>(0);
 
   const [wsState, setWsState] = useState<ConnectionState>("idle");
@@ -791,6 +794,11 @@ export function useCanvasPipeline(
           setTerraformOutdated(msg.terraform_outdated);
         }
 
+        const snapshotAgents = parseGenerationAgentsFromSnapshot(msg);
+        if (snapshotAgents) {
+          setGenerationAgents(snapshotAgents);
+        }
+
         const status = msg.generation_status;
         const stage = msg.generation_stage;
         if (typeof stage === "string") setCurrentStage(stage);
@@ -921,6 +929,7 @@ export function useCanvasPipeline(
         setIsGenerating(true);
         setPipelineStatus("Generation queued...");
         setCurrentStage("queued");
+        setGenerationAgents(null);
         setLastEventAt(Date.now());
         pushTicker("queued");
         setTerraformProgress((prev) => ({
@@ -1153,6 +1162,14 @@ export function useCanvasPipeline(
           return [...prev, entry].slice(-50);
         });
         setLastEventAt(Date.now());
+      }
+
+      if (msg.type === "generation_agent_update") {
+        const parsed = parseGenerationAgentUpdate(msg);
+        if (parsed) {
+          setGenerationAgents(parsed);
+          setLastEventAt(Date.now());
+        }
       }
 
       if (msg.type === "terraform_file") {
@@ -2045,6 +2062,7 @@ export function useCanvasPipeline(
     terraformOutdated,
     isGenerating,
     agentLogs,
+    generationAgents,
     generationElapsed,
     wsState,
     statusTicker,

--- a/frontend/lib/useWorkspace.ts
+++ b/frontend/lib/useWorkspace.ts
@@ -25,7 +25,7 @@ import {
   shouldRedirectUnauthenticatedRootToLogin,
 } from "@/lib/workspaceRedirect";
 
-export type RightPanelTab = "output" | "designs" | "templates";
+export type RightPanelTab = "generation" | "output" | "designs" | "templates";
 
 function currentPathWithQuery() {
   if (typeof window === "undefined") return "/";
@@ -85,7 +85,7 @@ export function useWorkspace() {
     {
       liveSession: Boolean(currentProject && isOwner),
       readOnly: currentProject ? !isOwner : !user,
-    }
+    },
   );
   const { loadTemplateSnapshot, reset, nodes, edges } = pipeline;
   const canvasBecameNonEmptyRef = useRef(false);
@@ -193,7 +193,18 @@ export function useWorkspace() {
   );
 
   const panels = useWorkspacePanels({ fetchProjects, requireAuth });
-  const { rightPanelOpen, rightPanelTab, openMyDesigns, openTemplates, openOutput, closeRightPanel } = panels;
+  const { rightPanelOpen, rightPanelTab, openMyDesigns, openTemplates, openOutput, openGeneration, closeRightPanel } = panels;
+
+  const generationAutoOpenedRef = useRef(false);
+  useEffect(() => {
+    if (pipeline.generationAgents && !generationAutoOpenedRef.current) {
+      generationAutoOpenedRef.current = true;
+      openGeneration();
+    }
+    if (!pipeline.generationAgents && !pipeline.isGenerating) {
+      generationAutoOpenedRef.current = false;
+    }
+  }, [pipeline.generationAgents, pipeline.isGenerating, openGeneration]);
 
   useEffect(() => {
     void refreshQuota();
@@ -351,6 +362,7 @@ export function useWorkspace() {
     openMyDesigns,
     openTemplates,
     openOutput,
+    openGeneration,
     closeRightPanel,
 
     projects,

--- a/frontend/lib/useWorkspace.ts
+++ b/frontend/lib/useWorkspace.ts
@@ -193,18 +193,61 @@ export function useWorkspace() {
   );
 
   const panels = useWorkspacePanels({ fetchProjects, requireAuth });
-  const { rightPanelOpen, rightPanelTab, openMyDesigns, openTemplates, openOutput, openGeneration, closeRightPanel } = panels;
+  const {
+    rightPanelOpen,
+    rightPanelTab,
+    openMyDesigns: openMyDesignsPanel,
+    openTemplates: openTemplatesPanel,
+    openOutput: openOutputPanel,
+    openGeneration,
+    closeRightPanel,
+  } = panels;
 
   const generationAutoOpenedRef = useRef(false);
+  const generationSuppressedRef = useRef(false);
+  const prevIsGeneratingRef = useRef(false);
+
+  const suppressGenerationAutoOpen = useCallback(() => {
+    if (pipeline.isGenerating) {
+      generationSuppressedRef.current = true;
+    }
+  }, [pipeline.isGenerating]);
+
+  const openMyDesigns = useCallback(() => {
+    suppressGenerationAutoOpen();
+    openMyDesignsPanel();
+  }, [openMyDesignsPanel, suppressGenerationAutoOpen]);
+
+  const openTemplates = useCallback(() => {
+    suppressGenerationAutoOpen();
+    openTemplatesPanel();
+  }, [openTemplatesPanel, suppressGenerationAutoOpen]);
+
+  const openOutput = useCallback(() => {
+    suppressGenerationAutoOpen();
+    openOutputPanel();
+  }, [openOutputPanel, suppressGenerationAutoOpen]);
+
   useEffect(() => {
-    if (pipeline.generationAgents && !generationAutoOpenedRef.current) {
-      generationAutoOpenedRef.current = true;
-      openGeneration();
-    }
-    if (!pipeline.generationAgents && !pipeline.isGenerating) {
+    const prev = prevIsGeneratingRef.current;
+    const curr = pipeline.isGenerating;
+
+    if (curr && !prev) {
       generationAutoOpenedRef.current = false;
+      generationSuppressedRef.current = false;
+      if (!generationSuppressedRef.current) {
+        generationAutoOpenedRef.current = true;
+        openGeneration();
+      }
     }
-  }, [pipeline.generationAgents, pipeline.isGenerating, openGeneration]);
+
+    if (!curr) {
+      generationAutoOpenedRef.current = false;
+      generationSuppressedRef.current = false;
+    }
+
+    prevIsGeneratingRef.current = curr;
+  }, [pipeline.isGenerating, openGeneration]);
 
   useEffect(() => {
     void refreshQuota();

--- a/frontend/lib/useWorkspacePanels.ts
+++ b/frontend/lib/useWorkspacePanels.ts
@@ -30,9 +30,14 @@ export function useWorkspacePanels({
     setRightPanelOpen(true);
   }, []);
 
+  const openGeneration = useCallback(() => {
+    setRightPanelTab("generation");
+    setRightPanelOpen(true);
+  }, []);
+
   const closeRightPanel = useCallback(() => {
     setRightPanelOpen(false);
   }, []);
 
-  return { rightPanelOpen, rightPanelTab, openMyDesigns, openTemplates, openOutput, closeRightPanel };
+  return { rightPanelOpen, rightPanelTab, openMyDesigns, openTemplates, openOutput, openGeneration, closeRightPanel };
 }


### PR DESCRIPTION
## Summary

Adds a dedicated "Architecture Generation" right-panel view that shows the three pipeline agents (Requirements, Architect, Cost analysis) as a vertical stepper with rich cards, user-friendly progress text, dependency-aware status, and mini-history.

Closes #190.

## What's in this PR

### Backend
- New in-memory generation observability model on `GenerationRuntime` for the three initial-generation agents
- New `generation_agent_update` websocket message — structured per-agent snapshot emitted after each lifecycle transition
- Failure propagation: if an agent fails, downstream agents show `blocked`
- `generation_agents` included in `generation_snapshot` while a generation is active for reconnect support
- Public `get_generation_observability(project_id)` accessor in `generation_service.py`

### Frontend
- New `generationObservability.ts` types and parser for the WS message
- `generation` tab added to `RightPanelTab` and `useWorkspacePanels`
- `generation_agent_update` and snapshot handlers in `useCanvasPipeline`
- Auto-open effect in `useWorkspace` that opens the generation panel on first agent update
- `GenerationObservabilityPanel` with `AgentStepCard` and `AgentStepMiniHistory` subcomponents
- Tests for the parser (`generationObservability.test.ts`)

### Docs
- `documents/platform-docs.md` — generation observability panel behavior, `generation_agent_update` message
- `documents/data-reference.md` — agent state shape, dependency chain, failure propagation, lifecycle

## Test results

Frontend: 32 test files passing, 187 tests passing (pre-existing `templates.test.ts` failure unrelated to this change).
Backend: requires env vars to run (expected); the new code follows existing patterns.

## Implementation details

- **Initial generation only**: observability is only emitted for `start_generation` flows. Chat edits, terraform generation, and reruns are not affected.
- **Lightweight**: in-memory state only, no DB schema changes, no long-term run history.
- **Styleguide-compliant**: uses existing color palette and spacing tokens.
- **Component rules**: each component under 150 lines, UI separated from logic.

## Plan reference

Full plan: `documents/plans/2026-04-11-generation-observability-panel.md`