### PR TITLE
fix: recover missed terraform files from generation snapshot

### DIFF
--- a/frontend/lib/__tests__/mergeTerraformFiles.test.ts
+++ b/frontend/lib/__tests__/mergeTerraformFiles.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { mergeTerraformFiles } from "../canvasHydration";
+import type { TerraformFile } from "@/components/OutputPanel";
+
+describe("mergeTerraformFiles", () => {
+  it("returns existing files when snapshot is empty during generation", () => {
+    const existing: TerraformFile[] = [
+      { filename: "main.tf", content: "# existing main", description: "" },
+      { filename: "variables.tf", content: "# vars", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, [], true);
+    expect(result).toEqual(existing);
+    expect(result.length).toBe(2);
+  });
+
+  it("merges snapshot into existing during active generation (recovers missed live file)", () => {
+    const existing: TerraformFile[] = [
+      { filename: "variables.tf", content: "# vars", description: "" },
+      { filename: "outputs.tf", content: "# outputs", description: "" },
+      { filename: "terraform.tfvars", content: "# tfvars", description: "" },
+    ];
+    const snapshot: TerraformFile[] = [
+      { filename: "main.tf", content: "# main from snapshot", description: "" },
+      { filename: "variables.tf", content: "# vars", description: "" },
+      { filename: "outputs.tf", content: "# outputs", description: "" },
+      { filename: "terraform.tfvars", content: "# tfvars", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, snapshot, true);
+    expect(result.length).toBe(4);
+    expect(result.find((f) => f.filename === "main.tf")?.content).toBe("# main from snapshot");
+    expect(result.find((f) => f.filename === "variables.tf")?.content).toBe("# vars");
+  });
+
+  it("replaces existing with snapshot when not generating", () => {
+    const existing: TerraformFile[] = [
+      { filename: "main.tf", content: "# old", description: "" },
+    ];
+    const snapshot: TerraformFile[] = [
+      { filename: "main.tf", content: "# new", description: "" },
+      { filename: "variables.tf", content: "# vars", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, snapshot, false);
+    expect(result).toEqual(snapshot);
+    expect(result.length).toBe(2);
+  });
+
+  it("does not overwrite newer live file with older snapshot file of same name", () => {
+    const existing: TerraformFile[] = [
+      { filename: "main.tf", content: "# newer live main", description: "" },
+      { filename: "variables.tf", content: "# vars", description: "" },
+    ];
+    const snapshot: TerraformFile[] = [
+      { filename: "main.tf", content: "# older snapshot main", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, snapshot, true);
+    expect(result.find((f) => f.filename === "main.tf")?.content).toBe("# newer live main");
+  });
+
+  it("recovers main.tf when it was missed in live events but present in snapshot", () => {
+    const liveOnlyFiles: TerraformFile[] = [
+      { filename: "variables.tf", content: "# vars", description: "" },
+      { filename: "outputs.tf", content: "# outputs", description: "" },
+      { filename: "terraform.tfvars", content: "# tfvars", description: "" },
+    ];
+    const snapshotWithMain: TerraformFile[] = [
+      { filename: "main.tf", content: "# recovered main", description: "" },
+      { filename: "variables.tf", content: "# vars", description: "" },
+      { filename: "outputs.tf", content: "# outputs", description: "" },
+      { filename: "terraform.tfvars", content: "# tfvars", description: "" },
+    ];
+    const result = mergeTerraformFiles(liveOnlyFiles, snapshotWithMain, true);
+    expect(result.length).toBe(4);
+    expect(result.some((f) => f.filename === "main.tf")).toBe(true);
+    expect(result.find((f) => f.filename === "main.tf")?.content).toBe("# recovered main");
+  });
+
+  it("returns existing when snapshot is empty and not generating", () => {
+    const existing: TerraformFile[] = [
+      { filename: "main.tf", content: "# existing", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, [], false);
+    expect(result).toEqual(existing);
+  });
+
+  it("handles null snapshot gracefully", () => {
+    const existing: TerraformFile[] = [
+      { filename: "main.tf", content: "# existing", description: "" },
+    ];
+    const result = mergeTerraformFiles(existing, null as unknown as TerraformFile[], true);
+    expect(result).toEqual(existing);
+  });
+});

--- a/frontend/lib/canvasHydration.ts
+++ b/frontend/lib/canvasHydration.ts
@@ -77,6 +77,31 @@ export function projectHydrationSnapshot(project: ProjectHydrationSnapshot): Pro
 
 export type ManualTerraformRunState = "idle" | "running" | "completed" | "failed";
 
+export function mergeTerraformFiles(
+  existingFiles: TerraformFile[],
+  snapshotFiles: TerraformFile[],
+  isGenerating: boolean,
+): TerraformFile[] {
+  if (!snapshotFiles || snapshotFiles.length === 0) {
+    return existingFiles;
+  }
+
+  if (!isGenerating) {
+    return snapshotFiles;
+  }
+
+  const merged = new Map<string, TerraformFile>();
+  for (const file of existingFiles) {
+    merged.set(file.filename, file);
+  }
+  for (const file of snapshotFiles) {
+    if (!merged.has(file.filename)) {
+      merged.set(file.filename, file);
+    }
+  }
+  return Array.from(merged.values());
+}
+
 type GetManualTerraformRunStateFromSnapshotArgs = {
   currentState: ManualTerraformRunState;
   generationStage: string | undefined;

--- a/frontend/lib/useCanvasPipeline.ts
+++ b/frontend/lib/useCanvasPipeline.ts
@@ -22,7 +22,7 @@ import type { GraphMutationPayload } from "@/lib/graphDiff";
 import type { TemplateDetail } from "@/lib/templates";
 import { resolveGenerationProjectId } from "./generationSession";
 import { shouldApplyLayoutOnPipelineEvent } from "./pipelineLayout";
-import { projectHydrationSnapshot, shouldApplySnapshotTerraformFiles, shouldHydrateFromProject, getManualTerraformRunStateFromSnapshot } from "./canvasHydration";
+import { projectHydrationSnapshot, mergeTerraformFiles, shouldHydrateFromProject, getManualTerraformRunStateFromSnapshot } from "./canvasHydration";
 import { createProject, saveSnapshot } from "./projectApi";
 import { ensureChatProjectContext, projectContextFromSession, type ChatProjectBootstrapState } from "./chatProjectContext";
 import { buildChatPayload, buildGenerateTerraformPayload, pipelineErrorToastMessage } from "./pipelineWsPayloads";
@@ -813,32 +813,19 @@ export function useCanvasPipeline(
         const snapshotTerraformFiles = Array.isArray(msg.terraform_files)
           ? (msg.terraform_files as TerraformFile[])
           : null;
-        const shouldApplySnapshotTerraform = shouldApplySnapshotTerraformFiles({
-          generationStatus: status,
-          isGenerating: isGeneratingRef.current,
-        });
-        const appliedSnapshotTerraformFiles = snapshotTerraformFiles && shouldApplySnapshotTerraform
-          ? snapshotTerraformFiles
-          : null;
-        if (snapshotTerraformFiles && shouldApplySnapshotTerraform) {
-          pushDebugEvent({
-            ts: Date.now(),
-            level: "info",
-            source: "local",
-            stage: "terraform",
-            message: `Applying snapshot terraform_files: ${snapshotTerraformFiles.length} files`,
-            traceId,
-          });
-          setTerraformFiles(snapshotTerraformFiles);
-        } else if (snapshotTerraformFiles && !shouldApplySnapshotTerraform) {
-          pushDebugEvent({
-            ts: Date.now(),
-            level: "warning",
-            source: "local",
-            stage: "terraform",
-            message: `Skipped snapshot terraform_files during active generation: ${snapshotTerraformFiles.length} files`,
-            traceId,
-          });
+        if (snapshotTerraformFiles && snapshotTerraformFiles.length > 0) {
+          const mergedFiles = mergeTerraformFiles(terraformFiles, snapshotTerraformFiles, isGeneratingRef.current);
+          if (mergedFiles.length !== terraformFiles.length || !mergedFiles.every((f, i) => f.filename === terraformFiles[i]?.filename && f.content === terraformFiles[i]?.content)) {
+            pushDebugEvent({
+              ts: Date.now(),
+              level: "info",
+              source: "local",
+              stage: "terraform",
+              message: `Merging snapshot terraform_files: ${snapshotTerraformFiles.length} snapshot + ${terraformFiles.length} existing → ${mergedFiles.length} total`,
+              traceId,
+            });
+            setTerraformFiles(mergedFiles);
+          }
         }
 
         if (typeof msg.terraform_outdated === "boolean") {


### PR DESCRIPTION
## Summary

Backend correctly generates and persists all Terraform files including `main.tf`, but the frontend had a recovery gap that caused `main.tf` to sometimes not appear in the UI while other files (`outputs.tf`, `variables.tf`, `terraform.tfvars`) did appear.

**Root cause:** When a live `terraform_file` WebSocket event was missed (e.g., due to client reconnect/subscribe timing), the recovery mechanism via `generation_snapshot.terraform_files` was intentionally skipped during active generation. Only terminal snapshots (`completed`/`failed`/`idle`) were applied. Since `main.tf` is emitted first in the generation order, it was the most likely to be the missed file.

## Changes

### frontend/lib/canvasHydration.ts
- Added `mergeTerraformFiles()` that during active generation merges snapshot files into existing local state — existing live files are preserved, only missing filenames are added from snapshot

### frontend/lib/useCanvasPipeline.ts
- Replaced all-or-nothing snapshot application with merge behavior during active generation
- Live `terraform_file` events still update/upsert files in real-time
- On `generation_snapshot`, non-empty snapshots now fill gaps in existing files rather than being ignored

### frontend/lib/__tests__/mergeTerraformFiles.test.ts
- New tests covering recovery scenarios:
  - `main.tf` recovered from snapshot when it was missed in live events
  - Newer live files not clobbered by older snapshot content
  - Empty snapshots don't wipe existing state during generation

Fixes the case where `main.tf` is missing from the Terraform viewer while other `.tf` files appear.