### PR TITLE
fix: resolve precommit lint errors in test files

### DIFF
--- a/frontend/lib/__tests__/diagramEventBuffer.test.ts
+++ b/frontend/lib/__tests__/diagramEventBuffer.test.ts
@@ -6,7 +6,6 @@ import {
   createEventBuffer,
   bufferDeferredEvent,
   drainDeferredEvents,
-  type DiagramEvent,
   type AddNodeEvent,
   type NodeExistsCheck,
 } from "../diagramEventBuffer";
@@ -82,7 +81,7 @@ describe("classifyNodeEvent", () => {
   });
 
   it("handles multi-region: region then vpc then service — correct ordering", () => {
-    let existing: string[] = [];
+    const existing: string[] = [];
 
     // Step 1: region arrives (root, no parent)
     const regionEvent: AddNodeEvent = {
@@ -254,7 +253,7 @@ describe("EventBuffer", () => {
   });
 
   it("simulates out-of-order streaming: child before parent, then parent arrives", () => {
-    let existing: string[] = [];
+    const existing: string[] = [];
     let buffer = createEventBuffer();
     const applied: AddNodeEvent[] = [];
 

--- a/frontend/lib/__tests__/generationSnapshotHydration.test.ts
+++ b/frontend/lib/__tests__/generationSnapshotHydration.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from "vitest";
 import { shouldHydrateGenerationSnapshot } from "../generationSnapshotHydration";
 import { parseGenerationAgentsFromSnapshot, mergeCodeGenerationAgents } from "../generationObservability";
 import type { GenerationAgentState } from "../generationObservability";
-import type { TerraformProgress } from "@/components/TerraformViewer";
-import { buildCoderAgentStateFromProgress } from "../terraformGenerationObservability";
 
 describe("shouldHydrateGenerationSnapshot", () => {
   it("hydrates when generation is not active", () => {


### PR DESCRIPTION
## Summary

Fixes 5 lint errors causing `pnpm lint` to fail with exit code 1:

- `frontend/lib/__tests__/diagramEventBuffer.test.ts:9` — removed unused `DiagramEvent` type import
- `frontend/lib/__tests__/diagramEventBuffer.test.ts:85,257` — changed `let existing` to `const existing` (never reassigned, only mutated via `.push()`)
- `frontend/lib/__tests__/generationSnapshotHydration.test.ts:5,6` — removed unused `TerraformProgress` and `buildCoderAgentStateFromProgress` imports

`pnpm lint` now passes (exit 0). One pre-existing warning remains in `useCanvasPipeline.ts:1507` (`react-hooks/exhaustive-deps`) — left as-is since it is non-blocking and pre-existing.

## Verification

```
pnpm lint  # Exit code 0, no errors
```