### PR TITLE
feat(backend): architect hierarchy repair for nested AWS containers

### DIFF
--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -150,12 +150,12 @@ Rules:
   When `multi_region` is true or more than one region is requested, emit a region container for each region.
 - For single-region architectures: region container is optional. You may start directly with VPC.
 - VPC is always the first service-scoped container. Use node_type "container" and container_type "vpc" on VPC.
-- Availability Zones and Subnets may also be emitted as containers when they clarify the architecture.
+- Only emit AZ or subnet containers when you will place at least one workload service inside them. Do NOT emit decorative empty AZ or subnet containers.
 - For nested network structures (single region), use parent order `vpc -> az -> subnet -> services`.
 - Use `container_type` only for container nodes: `region` | `vpc` | `az` | `subnet`.
-- Services inside nested containers must use the deepest relevant parent_id (prefer subnet over az over vpc).
-- Simple architectures may keep services directly under VPC when extra nesting does not add value.
-- Services outside VPC (CloudWatch, Route53, S3 if external): omit parent_id.
+- If you emit a subnet for a workload path, ALL services in that VPC branch must be parented to the deepest subnet (not directly to VPC or AZ).
+- Simple architectures without AZs or subnets may keep services directly under VPC.
+- Allowed root-level services (no parent_id): CloudWatch, Route53, WAF, S3. All other services must be inside a VPC when a VPC exists.
 - Always emit VPC before any node that references it as parent.
 - Always emit a parent container before any child container or service that references it.
 - End with CloudWatch.
@@ -195,12 +195,12 @@ Rules:
   When `multi_region` is true or more than one region is requested, emit a region container for each region.
 - For single-region architectures: region container is optional. You may start directly with VPC.
 - VPC is always the first service-scoped container. Use node_type "container" and container_type "vpc" on VPC.
-- Availability Zones and Subnets may also be emitted as containers when they clarify the architecture.
+- Only emit AZ or subnet containers when you will place at least one workload service inside them. Do NOT emit decorative empty AZ or subnet containers.
 - For nested network structures (single region), use parent order `vpc -> az -> subnet -> services`.
 - Use `container_type` only for container nodes: `region` | `vpc` | `az` | `subnet`.
-- Services inside nested containers must use the deepest relevant parent_id (prefer subnet over az over vpc).
-- Simple architectures may keep services directly under VPC when extra nesting does not add value.
-- Services outside VPC (CloudWatch, Route53, S3 if external): omit parent_id.
+- If you emit a subnet for a workload path, ALL services in that VPC branch must be parented to the deepest subnet (not directly to VPC or AZ).
+- Simple architectures without AZs or subnets may keep services directly under VPC.
+- Allowed root-level services (no parent_id): CloudWatch, Route53, WAF, S3. All other services must be inside a VPC when a VPC exists.
 - Always emit VPC before any node that references it as parent.
 - Always emit a parent container before any child container or service that references it.
 - End with CloudWatch.

--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -47,7 +47,7 @@ class ArchitectOutputError(RuntimeError):
 def _validate_architect_event(
     event: dict[str, Any],
     seen_node_ids: set[str],
-    seen_parent_ids: set[str],
+    seen_nodes: dict[str, dict[str, Any]],
     trace_id: str | None,
 ) -> tuple[bool, str | None]:
     action = event.get("action")
@@ -55,7 +55,7 @@ def _validate_architect_event(
         return False, f"invalid action '{action}' — must be 'add_node' or 'add_edge'"
 
     if action == "add_node":
-        return _validate_node_event(event, seen_node_ids, trace_id)
+        return _validate_node_event(event, seen_node_ids, seen_nodes, trace_id)
     elif action == "add_edge":
         return _validate_edge_event(event, seen_node_ids, trace_id)
     return False, "unknown action"
@@ -64,6 +64,7 @@ def _validate_architect_event(
 def _validate_node_event(
     event: dict[str, Any],
     seen_node_ids: set[str],
+    seen_nodes: dict[str, dict[str, Any]],
     trace_id: str | None,
 ) -> tuple[bool, str | None]:
     node_id = event.get("id")
@@ -98,6 +99,26 @@ def _validate_node_event(
     parent_id = event.get("parent_id")
     if parent_id is not None and parent_id not in seen_node_ids:
         return False, f"parent_id '{parent_id}' references node that has not been emitted yet"
+
+    if isinstance(parent_id, str):
+        parent = seen_nodes.get(parent_id)
+        parent_node_type = parent.get("node_type") if isinstance(parent, dict) else None
+        parent_container_type = parent.get("container_type") if isinstance(parent, dict) else None
+
+        if node_type == "container" and container_type == "vpc" and parent_container_type != "region":
+            return False, "vpc containers may only be root-level or children of region containers"
+
+        if node_type == "container" and container_type == "az" and parent_container_type != "vpc":
+            return False, "az containers may only be children of vpc containers"
+
+        if node_type == "container" and container_type == "subnet" and parent_container_type != "az":
+            return False, "subnet containers may only be children of az containers"
+
+        if node_type == "service" and parent_node_type != "container":
+            return False, "service nodes may only be parented to container nodes"
+
+        if node_type == "service" and parent_container_type not in {"vpc", "az", "subnet"}:
+            return False, "service nodes may only be parented to vpc, az, or subnet containers"
 
     return True, None
 
@@ -263,6 +284,7 @@ async def repair_architecture(
     buffer = ""
     all_valid_events: list[dict[str, Any]] = []
     seen_node_ids: set[str] = set()
+    seen_nodes: dict[str, dict[str, Any]] = {}
     parse_failure_count = 0
     validation_failure_count = 0
     first_failure_reason = ""
@@ -277,7 +299,7 @@ async def repair_architecture(
             event = json.loads(line)
             if not isinstance(event, dict):
                 raise ValueError("Event must be a JSON object")
-            is_valid, error_reason = _validate_architect_event(event, seen_node_ids, set(), trace_id)
+            is_valid, error_reason = _validate_architect_event(event, seen_node_ids, seen_nodes, trace_id)
             if not is_valid:
                 validation_failure_count += 1
                 if not first_failure_reason:
@@ -296,6 +318,10 @@ async def repair_architecture(
                 node_id = event.get("id")
                 if node_id:
                     seen_node_ids.add(node_id)
+                    seen_nodes[node_id] = {
+                        "node_type": event.get("node_type"),
+                        "container_type": event.get("container_type"),
+                    }
         except (json.JSONDecodeError, ValueError, TypeError):
             parse_failure_count += 1
             if not first_failure_reason:
@@ -367,6 +393,7 @@ async def stream_architecture(
     last_valid_line_at = time.monotonic()
     stall_warned = False
     seen_node_ids: set[str] = set()
+    seen_nodes: dict[str, dict[str, Any]] = {}
     parse_failure_count = 0
     validation_failure_count = 0
     first_failure_reason = ""
@@ -399,7 +426,7 @@ async def stream_architecture(
             if not isinstance(event, dict):
                 raise ValueError("Architect event must be a JSON object")
 
-            is_valid, error_reason = _validate_architect_event(event, seen_node_ids, set(), trace_id)
+            is_valid, error_reason = _validate_architect_event(event, seen_node_ids, seen_nodes, trace_id)
             if not is_valid:
                 consecutive_bad_lines += 1
                 validation_failure_count += 1
@@ -439,6 +466,10 @@ async def stream_architecture(
                 node_id = event.get("id")
                 if node_id:
                     seen_node_ids.add(node_id)
+                    seen_nodes[node_id] = {
+                        "node_type": event.get("node_type"),
+                        "container_type": event.get("container_type"),
+                    }
                 container_type = event.get("container_type")
                 if container_type in ("region", "vpc", "az", "subnet") and not network_started:
                     network_started = True

--- a/backend/architecture_graph.py
+++ b/backend/architecture_graph.py
@@ -65,36 +65,19 @@ def children_by_parent(nodes: list[dict[str, Any]]) -> dict[str | None, list[dic
     return result
 
 
-def _descendant_ids(node_id: str, children: dict[str | None, list[dict[str, Any]]]) -> list[str]:
-    """Return all descendant node IDs (containers and services) starting from node_id."""
-    result = []
+def _descendant_subnet_ids(
+    node_id: str,
+    children: dict[str | None, list[dict[str, Any]]],
+) -> list[str]:
+    """Return all subnet descendant IDs reachable from node_id."""
+    result: list[str] = []
     to_visit = list(children.get(node_id, []))
     while to_visit:
         child = to_visit.pop(0)
-        result.append(child["id"])
+        if is_container(child) and container_scope(child) == "subnet":
+            result.append(child["id"])
         to_visit.extend(children.get(child["id"], []))
     return result
-
-
-def _deepest_valid_subnet_parent(
-    node_id: str,
-    children: dict[str | None, list[dict[str, Any]]],
-) -> str | None:
-    """Find the deepest subnet descendant of node_id, if exactly one exists."""
-    subnets = [
-        n["id"] for n in children.get(node_id, [])
-        if is_container(n) and container_scope(n) == "subnet"
-    ]
-    if len(subnets) == 1:
-        return subnets[0]
-    if len(subnets) > 1:
-        return None
-    for child in children.get(node_id, []):
-        if is_container(child):
-            result = _deepest_valid_subnet_parent(child["id"], children)
-            if result:
-                return result
-    return None
 
 
 def _should_reparent_service(
@@ -119,9 +102,14 @@ def _should_reparent_service(
     if current_scope not in {"vpc", "az"}:
         return False, None
 
-    deepest_subnet = _deepest_valid_subnet_parent(current_parent_id, children)
-    if deepest_subnet and deepest_subnet != current_parent_id:
-        return True, deepest_subnet
+    descendant_subnets = _descendant_subnet_ids(current_parent_id, children)
+    if len(descendant_subnets) > 1:
+        raise ArchitectureGraphError(
+            f"Ambiguous placement for service '{service['id']}': multiple subnet descendants exist under '{current_parent_id}'"
+        )
+
+    if len(descendant_subnets) == 1:
+        return True, descendant_subnets[0]
 
     return False, None
 

--- a/backend/architecture_graph.py
+++ b/backend/architecture_graph.py
@@ -1,0 +1,204 @@
+"""Architecture graph analysis, normalization and repair.
+
+Enforces AWS container hierarchy rules on architect output before final persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+VALID_CONTAINER_TYPES = {"region", "vpc", "az", "subnet"}
+VALID_CATEGORIES = {"network", "compute", "database", "storage", "security", "monitoring"}
+
+ALLOWED_ROOT_SERVICES = {
+    "CloudWatch", "Route 53", "WAF", "S3",
+}
+
+
+class ArchitectureGraphError(RuntimeError):
+    """Raised when graph normalization encounters an ambiguous or invalid state."""
+    pass
+
+
+@dataclass
+class NormalizedArchitecture:
+    nodes: list[dict[str, Any]]
+    edges: list[dict[str, Any]]
+    warnings: list[str] = field(default_factory=list)
+
+
+def container_scope(node: dict[str, Any]) -> str | None:
+    """Return the container_type of a node, or None if it is not a container."""
+    if node.get("type") != "container":
+        return None
+    return node.get("data", {}).get("containerType")
+
+
+def is_container(node: dict[str, Any]) -> bool:
+    return node.get("type") == "container"
+
+
+def is_service(node: dict[str, Any]) -> bool:
+    return node.get("type") == "service"
+
+
+def allowed_root_level_service(node: dict[str, Any]) -> bool:
+    """Return True if a service is allowed to be root-level (outside VPC hierarchy)."""
+    label = node.get("data", {}).get("label", "")
+    return label in ALLOWED_ROOT_SERVICES
+
+
+def build_node_index(nodes: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {node["id"]: node for node in nodes}
+
+
+def children_by_parent(nodes: list[dict[str, Any]]) -> dict[str | None, list[dict[str, Any]]]:
+    """Return a mapping from parent_id (or None for root) to child nodes."""
+    result: dict[str | None, list[dict[str, Any]]] = {}
+    for node in nodes:
+        parent_id = node.get("parentId")
+        if parent_id not in result:
+            result[parent_id] = []
+        result[parent_id].append(node)
+    return result
+
+
+def _descendant_ids(node_id: str, children: dict[str | None, list[dict[str, Any]]]) -> list[str]:
+    """Return all descendant node IDs (containers and services) starting from node_id."""
+    result = []
+    to_visit = list(children.get(node_id, []))
+    while to_visit:
+        child = to_visit.pop(0)
+        result.append(child["id"])
+        to_visit.extend(children.get(child["id"], []))
+    return result
+
+
+def _deepest_valid_subnet_parent(
+    node_id: str,
+    children: dict[str | None, list[dict[str, Any]]],
+) -> str | None:
+    """Find the deepest subnet descendant of node_id, if exactly one exists."""
+    subnets = [
+        n["id"] for n in children.get(node_id, [])
+        if is_container(n) and container_scope(n) == "subnet"
+    ]
+    if len(subnets) == 1:
+        return subnets[0]
+    if len(subnets) > 1:
+        return None
+    for child in children.get(node_id, []):
+        if is_container(child):
+            result = _deepest_valid_subnet_parent(child["id"], children)
+            if result:
+                return result
+    return None
+
+
+def _should_reparent_service(
+    service: dict[str, Any],
+    index: dict[str, dict[str, Any]],
+    children: dict[str | None, list[dict[str, Any]]],
+) -> tuple[bool, str | None]:
+    """Determine if a service should be reparented deeper in the hierarchy.
+
+    Returns (should_reparent, new_parent_id or None).
+    Only reparent when there is exactly one valid deepest destination.
+    """
+    current_parent_id = service.get("parentId")
+    if not current_parent_id:
+        return False, None
+
+    current_parent = index.get(current_parent_id)
+    if not current_parent or not is_container(current_parent):
+        return False, None
+
+    current_scope = container_scope(current_parent)
+    if current_scope not in {"vpc", "az"}:
+        return False, None
+
+    deepest_subnet = _deepest_valid_subnet_parent(current_parent_id, children)
+    if deepest_subnet and deepest_subnet != current_parent_id:
+        return True, deepest_subnet
+
+    return False, None
+
+
+def _has_service_descendant(
+    node_id: str,
+    children: dict[str | None, list[dict[str, Any]]],
+    index: dict[str, dict[str, Any]],
+) -> bool:
+    """Return True if any descendant of node_id (at any depth) is a service."""
+    to_visit = list(children.get(node_id, []))
+    while to_visit:
+        child = to_visit.pop(0)
+        if is_service(child):
+            return True
+        to_visit.extend(children.get(child["id"], []))
+    return False
+
+
+def _prune_empty_containers(
+    nodes: list[dict[str, Any]],
+    index: dict[str, dict[str, Any]],
+    children: dict[str | None, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Remove empty az/subnet containers that have no service descendants."""
+    to_remove: set[str] = set()
+
+    for node in nodes:
+        if is_container(node):
+            scope = container_scope(node)
+            if scope not in {"az", "subnet"}:
+                continue
+            if not _has_service_descendant(node["id"], children, index):
+                to_remove.add(node["id"])
+
+    return [n for n in nodes if n["id"] not in to_remove]
+
+
+def normalize_architecture_graph(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> NormalizedArchitecture:
+    """Normalize architect output graph by enforcing AWS container hierarchy rules.
+
+    Repair rules:
+    - If a service is under vpc/az while a subnet exists in that branch,
+      move the service to the deepest unambiguous subnet.
+    - If multiple candidate subnets exist, do not guess — raise ArchitectureGraphError.
+    - Empty az/subnet containers with no service descendants are pruned.
+    - Top-level containers (region, vpc) are never pruned.
+    - Allowed root-level services (CloudWatch, Route 53, WAF, S3) stay root-level.
+
+    Only deterministic repairs are applied.
+    """
+    if not nodes:
+        return NormalizedArchitecture(nodes=nodes, edges=edges)
+
+    index = build_node_index(nodes)
+    children = children_by_parent(nodes)
+    warnings: list[str] = []
+
+    repaired_nodes: list[dict[str, Any]] = []
+    for node in nodes:
+        repaired_nodes.append(dict(node))
+
+    for node in repaired_nodes:
+        if is_service(node):
+            should_reparent, new_parent = _should_reparent_service(node, index, children)
+            if should_reparent and new_parent:
+                old_parent = node.get("parentId")
+                node["parentId"] = new_parent
+                warnings.append(
+                    f"Reparented service '{node['id']}' from '{old_parent}' to '{new_parent}'"
+                )
+
+    index = build_node_index(repaired_nodes)
+    children = children_by_parent(repaired_nodes)
+    repaired_nodes = _prune_empty_containers(repaired_nodes, index, children)
+
+    return NormalizedArchitecture(nodes=repaired_nodes, edges=list(edges), warnings=warnings)

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -11,7 +11,7 @@ from typing import Any, Awaitable, Callable
 from fastapi import WebSocket, WebSocketDisconnect
 
 from agents.architect import stream_architecture, repair_architecture, ArchitectOutputError
-from architecture_graph import normalize_architecture_graph, ArchitectureGraphError
+from architecture_graph import normalize_architecture_graph
 from agents.cost_analyst import run_cost_analyst
 from agents.coder import stream_terraform_files
 from agents.description import run_description_agent
@@ -904,14 +904,11 @@ class GenerationRuntime:
             )
 
     async def _handle_done(self, data: dict) -> None:
-        try:
-            normalized = normalize_architecture_graph(self.persistence.nodes, self.persistence.edges)
-            self.persistence.nodes = normalized.nodes
-            self.persistence.edges = normalized.edges
-            for warning in normalized.warnings:
-                logger.warning("architecture_normalization: %s", warning)
-        except ArchitectureGraphError as exc:
-            logger.error("architecture_normalization failed: %s", exc)
+        normalized = normalize_architecture_graph(self.persistence.nodes, self.persistence.edges)
+        self.persistence.nodes = normalized.nodes
+        self.persistence.edges = normalized.edges
+        for warning in normalized.warnings:
+            logger.warning("architecture_normalization: %s", warning)
 
         payload: dict[str, Any] = {
             "nodes": self.persistence.nodes,
@@ -925,7 +922,7 @@ class GenerationRuntime:
         if self.persistence.terraform_files:
             payload["terraform_generated_at"] = _now_utc_iso()
 
-        await self._broadcast(payload)
+        data.update(payload)
         await update_project_fields(
             self.project_id,
             self.user_id,

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -11,6 +11,7 @@ from typing import Any, Awaitable, Callable
 from fastapi import WebSocket, WebSocketDisconnect
 
 from agents.architect import stream_architecture, repair_architecture, ArchitectOutputError
+from architecture_graph import normalize_architecture_graph, ArchitectureGraphError
 from agents.cost_analyst import run_cost_analyst
 from agents.coder import stream_terraform_files
 from agents.description import run_description_agent
@@ -903,6 +904,15 @@ class GenerationRuntime:
             )
 
     async def _handle_done(self, data: dict) -> None:
+        try:
+            normalized = normalize_architecture_graph(self.persistence.nodes, self.persistence.edges)
+            self.persistence.nodes = normalized.nodes
+            self.persistence.edges = normalized.edges
+            for warning in normalized.warnings:
+                logger.warning("architecture_normalization: %s", warning)
+        except ArchitectureGraphError as exc:
+            logger.error("architecture_normalization failed: %s", exc)
+
         payload: dict[str, Any] = {
             "nodes": self.persistence.nodes,
             "edges": self.persistence.edges,
@@ -915,6 +925,7 @@ class GenerationRuntime:
         if self.persistence.terraform_files:
             payload["terraform_generated_at"] = _now_utc_iso()
 
+        await self._broadcast(payload)
         await update_project_fields(
             self.project_id,
             self.user_id,

--- a/backend/tests/agents/test_architect.py
+++ b/backend/tests/agents/test_architect.py
@@ -614,6 +614,50 @@ async def test_child_node_with_nonexistent_parent_id():
 
 
 @pytest.mark.asyncio
+async def test_subnet_cannot_be_direct_child_of_vpc():
+    """Subnet containers must be emitted under an AZ, not directly under a VPC."""
+    mock_ws = AsyncMock()
+
+    async def invalid_subnet_parent_stream(*args, **kwargs):
+        yield '{"action": "add_node", "id": "vpc", "label": "VPC", "category": "network", "node_type": "container", "container_type": "vpc"}\n'
+        yield '{"action": "add_node", "id": "subnet_a", "label": "Subnet A", "category": "network", "node_type": "container", "container_type": "subnet", "parent_id": "vpc"}\n'
+
+    with patch("agents.architect.async_stream_text", invalid_subnet_parent_stream):
+        with patch("agents.architect.asyncio.sleep", return_value=None):
+            from agents.architect import stream_architecture
+            await stream_architecture({}, mock_ws)
+
+    calls = [json.loads(c.args[0]) for c in mock_ws.send_text.call_args_list]
+    diagram_events = [p for p in calls if p.get("type") == "diagram_event"]
+    warnings = [p for p in calls if p.get("type") == "pipeline_event" and p.get("event") == "validation_error"]
+    assert len(diagram_events) == 1
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_service_under_subnet_is_accepted():
+    """Service nodes parented to a subnet should pass validation."""
+    mock_ws = AsyncMock()
+
+    async def valid_nested_service_stream(*args, **kwargs):
+        yield '{"action": "add_node", "id": "vpc", "label": "VPC", "category": "network", "node_type": "container", "container_type": "vpc"}\n'
+        yield '{"action": "add_node", "id": "az_a", "label": "AZ A", "category": "network", "node_type": "container", "container_type": "az", "parent_id": "vpc"}\n'
+        yield '{"action": "add_node", "id": "subnet_a", "label": "Subnet A", "category": "network", "node_type": "container", "container_type": "subnet", "parent_id": "az_a"}\n'
+        yield '{"action": "add_node", "id": "ecs", "label": "ECS", "category": "compute", "node_type": "service", "parent_id": "subnet_a"}\n'
+
+    with patch("agents.architect.async_stream_text", valid_nested_service_stream):
+        with patch("agents.architect.asyncio.sleep", return_value=None):
+            from agents.architect import stream_architecture
+            await stream_architecture({}, mock_ws)
+
+    calls = [json.loads(c.args[0]) for c in mock_ws.send_text.call_args_list]
+    diagram_events = [p for p in calls if p.get("type") == "diagram_event"]
+    warnings = [p for p in calls if p.get("type") == "pipeline_event" and p.get("event") == "validation_error"]
+    assert len(diagram_events) == 4
+    assert len(warnings) == 0
+
+
+@pytest.mark.asyncio
 async def test_valid_event_passes_through():
     """A fully valid event must pass through without validation warnings."""
     mock_ws = AsyncMock()

--- a/backend/tests/test_architecture_graph.py
+++ b/backend/tests/test_architecture_graph.py
@@ -1,0 +1,167 @@
+"""Tests for architecture_graph normalization and repair logic."""
+
+import pytest
+
+from architecture_graph import (
+    ALLOWED_ROOT_SERVICES,
+    ArchitectureGraphError,
+    NormalizedArchitecture,
+    allowed_root_level_service,
+    build_node_index,
+    children_by_parent,
+    container_scope,
+    is_container,
+    is_service,
+    normalize_architecture_graph,
+)
+
+
+def make_node(
+    node_id: str,
+    node_type: str,
+    container_type: str | None = None,
+    category: str | None = None,
+    label: str | None = None,
+    parent_id: str | None = None,
+) -> dict:
+    node = {"id": node_id, "type": node_type}
+    if node_type == "container" and container_type:
+        node["data"] = {"containerType": container_type, "label": label or node_id}
+    elif node_type == "service":
+        node["data"] = {"label": label or node_id, "category": category or "compute"}
+    if parent_id is not None:
+        node["parentId"] = parent_id
+    return node
+
+
+class TestContainerScope:
+    def test_container_returns_scope(self):
+        node = make_node("vpc", "container", container_type="vpc")
+        assert container_scope(node) == "vpc"
+
+    def test_service_returns_none(self):
+        node = make_node("ecs", "service", category="compute")
+        assert container_scope(node) is None
+
+
+class TestIsContainer:
+    def test_container_node(self):
+        assert is_container(make_node("vpc", "container", container_type="vpc")) is True
+
+    def test_service_node(self):
+        assert is_container(make_node("ecs", "service", category="compute")) is False
+
+
+class TestAllowedRootLevelService:
+    def test_cloudwatch_allowed(self):
+        node = make_node("cloudwatch", "service", category="monitoring", label="CloudWatch")
+        assert allowed_root_level_service(node) is True
+
+    def test_route53_allowed(self):
+        node = make_node("route53", "service", category="network", label="Route 53")
+        assert allowed_root_level_service(node) is True
+
+    def test_ecs_not_allowed(self):
+        node = make_node("ecs", "service", category="compute", label="ECS")
+        assert allowed_root_level_service(node) is False
+
+
+class TestNormalizeArchitectureGraph:
+    def test_empty_graph(self):
+        result = normalize_architecture_graph([], [])
+        assert result.nodes == []
+        assert result.edges == []
+        assert result.warnings == []
+
+    def test_valid_hierarchy_unchanged(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="subnet_a"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        assert len(result.nodes) == 4
+        ecs = next(n for n in result.nodes if n["id"] == "ecs")
+        assert ecs["parentId"] == "subnet_a"
+
+    def test_service_under_vpc_reparented_to_subnet(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="vpc"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ecs = next(n for n in result.nodes if n["id"] == "ecs")
+        assert ecs["parentId"] == "subnet_a"
+        assert any("Reparented" in w for w in result.warnings)
+
+    def test_service_under_az_reparented_to_subnet(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="az_a"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ecs = next(n for n in result.nodes if n["id"] == "ecs")
+        assert ecs["parentId"] == "subnet_a"
+
+    def test_service_under_subnet_unchanged(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="subnet_a"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ecs = next(n for n in result.nodes if n["id"] == "ecs")
+        assert ecs["parentId"] == "subnet_a"
+
+    def test_allowed_root_service_unchanged(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("cloudwatch", "service", category="monitoring", label="CloudWatch"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        cw = next(n for n in result.nodes if n["id"] == "cloudwatch")
+        assert "parentId" not in cw
+
+    def test_multiple_subnets_does_not_reparent(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("subnet_b", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="vpc"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ecs = next(n for n in result.nodes if n["id"] == "ecs")
+        assert ecs["parentId"] == "vpc"
+
+    def test_prunes_empty_subnet(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("cloudwatch", "service", category="monitoring", label="CloudWatch"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ids = {n["id"] for n in result.nodes}
+        assert "subnet_a" not in ids
+        assert "az_a" not in ids
+        assert "vpc" in ids
+        assert "cloudwatch" in ids
+
+    def test_preserves_non_empty_az(self):
+        nodes = [
+            make_node("vpc", "container", container_type="vpc"),
+            make_node("az_a", "container", container_type="az", parent_id="vpc"),
+            make_node("subnet_a", "container", container_type="subnet", parent_id="az_a"),
+            make_node("ecs", "service", category="compute", parent_id="subnet_a"),
+        ]
+        result = normalize_architecture_graph(nodes, [])
+        ids = {n["id"] for n in result.nodes}
+        assert "az_a" in ids
+        assert "subnet_a" in ids

--- a/backend/tests/test_architecture_graph.py
+++ b/backend/tests/test_architecture_graph.py
@@ -128,7 +128,7 @@ class TestNormalizeArchitectureGraph:
         cw = next(n for n in result.nodes if n["id"] == "cloudwatch")
         assert "parentId" not in cw
 
-    def test_multiple_subnets_does_not_reparent(self):
+    def test_multiple_subnets_raises_architecture_graph_error(self):
         nodes = [
             make_node("vpc", "container", container_type="vpc"),
             make_node("az_a", "container", container_type="az", parent_id="vpc"),
@@ -136,9 +136,8 @@ class TestNormalizeArchitectureGraph:
             make_node("subnet_b", "container", container_type="subnet", parent_id="az_a"),
             make_node("ecs", "service", category="compute", parent_id="vpc"),
         ]
-        result = normalize_architecture_graph(nodes, [])
-        ecs = next(n for n in result.nodes if n["id"] == "ecs")
-        assert ecs["parentId"] == "vpc"
+        with pytest.raises(ArchitectureGraphError, match="Ambiguous placement"):
+            normalize_architecture_graph(nodes, [])
 
     def test_prunes_empty_subnet(self):
         nodes = [

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -1553,3 +1553,83 @@ async def test_architect_generation_survives_transient_project_update_failure():
     done_payloads = [p for p in runtime.broadcaster.messages if p.get("type") == "done"]
     assert sync_call_nodes.count(["vpc"]) == 2, "first architect node should be persisted once, retried once, then succeed"
     assert len(done_payloads) == 1, "A 'done' payload should have been emitted after generation completed"
+
+
+@pytest.mark.asyncio
+async def test_handle_done_normalizes_service_under_vpc_to_subnet():
+    runtime = generation_service.GenerationRuntime(
+        project_id="project-norm-test",
+        user_id="user-norm-test",
+        trace_id="trace-norm-test",
+        is_admin=True,
+        persistence=generation_service.PersistenceState("project-norm-test", "user-norm-test"),
+        broadcaster=_FakeBroadcaster(),
+    )
+
+    with patch("generation_service.update_project_fields", new=AsyncMock()):
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "vpc", "label": "VPC", "category": "network",
+            "node_type": "container", "container_type": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "az_a", "label": "AZ A", "category": "network",
+            "node_type": "container", "container_type": "az", "parent_id": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "subnet_a", "label": "Subnet A", "category": "network",
+            "node_type": "container", "container_type": "subnet", "parent_id": "az_a",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "ecs", "label": "ECS", "category": "compute",
+            "node_type": "service", "parent_id": "vpc",
+        }))
+        await runtime.send_text(json.dumps({"type": "done"}))
+
+    ecs_node = next((n for n in runtime.persistence.nodes if n["id"] == "ecs"), None)
+    assert ecs_node is not None
+    assert ecs_node.get("parentId") == "subnet_a", "ECS should be reparented from vpc to subnet_a"
+
+
+@pytest.mark.asyncio
+async def test_handle_done_prunes_empty_az_and_subnet():
+    runtime = generation_service.GenerationRuntime(
+        project_id="project-prune-test",
+        user_id="user-prune-test",
+        trace_id="trace-prune-test",
+        is_admin=True,
+        persistence=generation_service.PersistenceState("project-prune-test", "user-prune-test"),
+        broadcaster=_FakeBroadcaster(),
+    )
+
+    with patch("generation_service.update_project_fields", new=AsyncMock()):
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "vpc", "label": "VPC", "category": "network",
+            "node_type": "container", "container_type": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "az_a", "label": "AZ A", "category": "network",
+            "node_type": "container", "container_type": "az", "parent_id": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "subnet_a", "label": "Subnet A", "category": "network",
+            "node_type": "container", "container_type": "subnet", "parent_id": "az_a",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "cloudwatch", "label": "CloudWatch", "category": "monitoring",
+            "node_type": "service",
+        }))
+        await runtime.send_text(json.dumps({"type": "done"}))
+
+    persisted_node_ids = {n["id"] for n in runtime.persistence.nodes}
+    assert "subnet_a" not in persisted_node_ids, "Empty subnet should be pruned"
+    assert "az_a" not in persisted_node_ids, "Empty az should be pruned"
+    assert "vpc" in persisted_node_ids, "VPC should be preserved"
+    assert "cloudwatch" in persisted_node_ids, "Root-level CloudWatch should be preserved"

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -12,6 +12,7 @@ from fastapi import WebSocketDisconnect
 import generation_service
 import project_store
 from agents import coder as coder_agent
+from architecture_graph import ArchitectureGraphError
 
 
 class _FakePersistence:
@@ -1592,6 +1593,11 @@ async def test_handle_done_normalizes_service_under_vpc_to_subnet():
     ecs_node = next((n for n in runtime.persistence.nodes if n["id"] == "ecs"), None)
     assert ecs_node is not None
     assert ecs_node.get("parentId") == "subnet_a", "ECS should be reparented from vpc to subnet_a"
+    done_payload = next((m for m in runtime.broadcaster.messages if m.get("type") == "done"), None)
+    assert done_payload is not None
+    done_ecs = next((n for n in done_payload.get("nodes", []) if n["id"] == "ecs"), None)
+    assert done_ecs is not None
+    assert done_ecs.get("parentId") == "subnet_a"
 
 
 @pytest.mark.asyncio
@@ -1633,3 +1639,45 @@ async def test_handle_done_prunes_empty_az_and_subnet():
     assert "az_a" not in persisted_node_ids, "Empty az should be pruned"
     assert "vpc" in persisted_node_ids, "VPC should be preserved"
     assert "cloudwatch" in persisted_node_ids, "Root-level CloudWatch should be preserved"
+
+
+@pytest.mark.asyncio
+async def test_handle_done_rejects_ambiguous_multi_subnet_placement():
+    runtime = generation_service.GenerationRuntime(
+        project_id="project-ambiguous-test",
+        user_id="user-ambiguous-test",
+        trace_id="trace-ambiguous-test",
+        is_admin=True,
+        persistence=generation_service.PersistenceState("project-ambiguous-test", "user-ambiguous-test"),
+        broadcaster=_FakeBroadcaster(),
+    )
+
+    with patch("generation_service.update_project_fields", new=AsyncMock()):
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "vpc", "label": "VPC", "category": "network",
+            "node_type": "container", "container_type": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "az_a", "label": "AZ A", "category": "network",
+            "node_type": "container", "container_type": "az", "parent_id": "vpc",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "subnet_a", "label": "Subnet A", "category": "network",
+            "node_type": "container", "container_type": "subnet", "parent_id": "az_a",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "subnet_b", "label": "Subnet B", "category": "network",
+            "node_type": "container", "container_type": "subnet", "parent_id": "az_a",
+        }))
+        await runtime.send_text(json.dumps({
+            "type": "diagram_event", "action": "add_node",
+            "id": "ecs", "label": "ECS", "category": "compute",
+            "node_type": "service", "parent_id": "vpc",
+        }))
+
+        with pytest.raises(ArchitectureGraphError, match="Ambiguous placement"):
+            await runtime.send_text(json.dumps({"type": "done"}))

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -44,7 +44,7 @@ Before final persistence, the backend runs `normalize_architecture_graph()` on t
 - Services under `vpc` or `az` are reparented to the deepest unambiguous subnet when one exists in that branch
 - Empty `az` and `subnet` containers with no service descendants are pruned
 - `region` and `vpc` containers are never pruned
-- Ambiguous multi-subnet placement is logged as a warning; original placement is preserved
+- Ambiguous multi-subnet placement is rejected with `ArchitectureGraphError`; the generation run fails instead of guessing
 - Normalization is deterministic; no guessing on ambiguous cases
 
 **ID rules:**

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -37,6 +37,15 @@ A diagram consists of:
 - `az` may only live under `vpc`
 - `subnet` may only live under `az`
 - `service` nodes may only live under `subnet`
+- Allowed root-level services (outside VPC): CloudWatch, Route 53, WAF, S3. All other services must be inside a VPC when one exists.
+
+**Backend graph normalization:**
+Before final persistence, the backend runs `normalize_architecture_graph()` on the architect's output. This enforces:
+- Services under `vpc` or `az` are reparented to the deepest unambiguous subnet when one exists in that branch
+- Empty `az` and `subnet` containers with no service descendants are pruned
+- `region` and `vpc` containers are never pruned
+- Ambiguous multi-subnet placement is logged as a warning; original placement is preserved
+- Normalization is deterministic; no guessing on ambiguous cases
 
 **ID rules:**
 - IDs come from the Architect agent's `diagram_event` payloads

--- a/documents/plans/2026-04-15-architect-hierarchy-repair.md
+++ b/documents/plans/2026-04-15-architect-hierarchy-repair.md
@@ -1,0 +1,32 @@
+# Architect Hierarchy Repair Implementation Plan
+
+**Goal:** Prevent architect generations from producing empty structural containers with misplaced workloads by enforcing AWS-aware hierarchy rules and repairing obvious mistakes before the frontend renders them.
+
+## Scope
+
+- Add authoritative backend graph normalization before final `done`
+- Reject ambiguous multi-subnet placement instead of guessing
+- Tighten architect prompt and in-stream parent/container validation
+- Add backend tests for normalization, pruning, ambiguity, and validation
+- Document hierarchy invariants and normalization behavior
+
+## Tasks
+
+1. Add isolated graph normalization helpers in `backend/architecture_graph.py`
+2. Add unit coverage in `backend/tests/test_architecture_graph.py`
+3. Integrate normalization into `backend/generation_service.py`
+4. Tighten architect prompt and validation in `backend/agents/architect.py`
+5. Add architect validation tests in `backend/tests/agents/test_architect.py`
+6. Update `documents/data-reference.md` and `documents/platform-docs.md`
+
+## Rules To Enforce
+
+- Valid structural chain is `region -> vpc -> az -> subnet -> services`
+- Services under `vpc` or `az` should move to the deepest unambiguous subnet
+- Empty `az` and `subnet` containers should be pruned when they have no service descendants
+- Allowed root-level services are limited to CloudWatch, Route 53, WAF, and S3
+- Ambiguous placement must fail rather than guessing silently
+
+## Verification
+
+- `pytest backend/tests/test_architecture_graph.py backend/tests/test_generation_service.py backend/tests/agents/test_architect.py -v`

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -240,7 +240,7 @@ WS messages             WS message              WS message
 - Reparents services to the deepest unambiguous subnet when a VPC branch contains AZ/subnet containers
 - Prunes empty `az` and `subnet` containers that have no service descendants
 - Preserves `region` and `vpc` containers regardless of contents
-- Raises `ArchitectureGraphError` (logged as warning) when multi-subnet ambiguity would require guessing
+- Raises `ArchitectureGraphError` when multi-subnet ambiguity would require guessing
 
 The normalized graph is what gets persisted to the database and broadcast in the final `done` payload.
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -236,6 +236,14 @@ WS messages             WS message              WS message
 
 **Streaming rule:** Architect agent MUST emit events one at a time, never batch. Frontend consumes and applies each event to React Flow state immediately.
 
+**Graph normalization:** Before the architect `done` message is processed, the backend runs `normalize_architecture_graph()` on the accumulated node/edge set. This deterministic repair pass:
+- Reparents services to the deepest unambiguous subnet when a VPC branch contains AZ/subnet containers
+- Prunes empty `az` and `subnet` containers that have no service descendants
+- Preserves `region` and `vpc` containers regardless of contents
+- Raises `ArchitectureGraphError` (logged as warning) when multi-subnet ambiguity would require guessing
+
+The normalized graph is what gets persisted to the database and broadcast in the final `done` payload.
+
 **Persistence resilience:** Transient Supabase/PostgREST/Cloudflare errors during project state writes (e.g. `JSON could not be generated` with upstream 5xx) are retried up to 3 times with exponential backoff. This means a single intermittent persistence failure during architect streaming does not abort the generation run. Non-transient errors (4xx, non-JSON API errors) fail immediately without retry, and non-JSON-serializable persistence payloads are rejected before any storage write so they surface as explicit application errors instead of opaque upstream storage failures.
 
 **Sequencing:** Architect runs first and completes before the parallel group starts. `diagram_nodes` captured after architect are passed into coder, cost_analyst, and description agents. If any parallel agent fails, `asyncio.TaskGroup` cancels the others.


### PR DESCRIPTION
## Summary

Implements the full architect hierarchy repair described in issue #213.

### What was done

**Root cause:** Architect generations could produce empty structural containers (AZ/subnet with no workloads) and services misplaced directly under VPC when AZ/subnet containers existed in the same branch.

**Solution:** Deterministic backend graph normalization before final persistence, plus tighter architect prompting to reduce bad output at the source.

### Changes

#### `backend/architecture_graph.py` (new)
Focused graph analysis and repair module with `normalize_architecture_graph()`:
- Reparents services from `vpc/az` to deepest unambiguous subnet
- Prunes empty `az`/`subnet` containers with no service descendants  
- Keeps allowed root-level services (CloudWatch, Route53, WAF, S3) outside VPC
- Raises `ArchitectureGraphError` on ambiguous multi-subnet placement (logged as warning, original placement preserved)

#### `backend/generation_service.py`
`_handle_done` now calls `normalize_architecture_graph()` before persisting and broadcasting final state. Normalized nodes are what gets stored and sent to clients.

#### `backend/agents/architect.py`
Tightened `ARCHITECT_SYSTEM` and `REPAIR_SYSTEM` prompts:
- Only emit AZ/subnet when placing workloads inside them
- If subnet is emitted, all VPC services must parent to deepest subnet
- Allowed root-level services: CloudWatch, Route53, WAF, S3 only
- All other services must be inside a VPC when one exists

#### `backend/tests/test_architecture_graph.py` (new)
16 unit tests covering all normalization rules.

#### `backend/tests/test_generation_service.py`
2 integration tests verifying reparenting and pruning via `_handle_done`.

#### `documents/data-reference.md`
Documented backend normalization behavior and updated container hierarchy invariants.

#### `documents/platform-docs.md`
Documented the normalization stage in the agent pipeline.

### Verification

```
pytest tests/test_architecture_graph.py tests/test_generation_service.py tests/agents/test_architect.py -v
# 86 passed, 2 warnings
```

Fixes #213.