### PR TITLE
fix(backend): mutation planner repair/retry for cost-optimization prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Thumbs.db
 .worktrees/
 .worktrees/
 .worktrees/
+.worktrees/

--- a/backend/agents/mutation_agent.py
+++ b/backend/agents/mutation_agent.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from typing import Any
 
 from llm_client import async_complete
 
 from agents.mutation_schema import MutationPlan
+
+logger = logging.getLogger(__name__)
 
 MUTATION_SYSTEM_PROMPT = """You are the DrawToCloud mutation planner.
 
@@ -45,7 +48,8 @@ Rules:
   expected impact/trade-offs, and a clear approval cue to click "Implement plan".
 - assistant_message must not claim that Terraform was regenerated. Terraform regeneration is always manual.
 - For cost reduction: analyze current cost_estimate data, prioritize rightsizing expensive components first.
-  Explain in assistant_message which specific changes reduce cost and by how much.
+  Explain in assistant_message which specific changes reduce cost and by how much. If cost_estimate is missing,
+  state your assumptions clearly and recommend the user verify actual costs.
 - For compute migration (e.g., "use serverless instead of EC2"): remove old compute nodes, add new ones,
   update edges to connect the new service. Explain the trade-offs.
 - For adding services (e.g., "add a CDN"): add the new node with proper category and edges to existing nodes.
@@ -53,6 +57,29 @@ Rules:
 - For security hardening: add WAF, Security Groups, or IAM nodes as appropriate.
 - For reliability improvements: suggest multi-AZ, Auto Scaling, or redundant services.
 - For simplification: consolidate services, remove unnecessary components.
+"""
+
+REPAIR_SYSTEM_PROMPT = """You repair malformed DrawToCloud mutation plan payloads.
+
+Given the original user goal, project context, and a previous invalid model response,
+output a corrected mutation plan JSON.
+
+Requirements:
+- Output ONLY valid JSON.
+- Top-level value must be an object with required fields:
+  - assistant_message: non-empty string explaining the plan
+  - reasoning: string (can be empty)
+  - constraints_respected: array of strings
+  - diff: object with any of: add_nodes, edit_nodes, delete_node_ids, add_edges, edit_edges, delete_edge_ids
+- Required diff fields when changes are proposed:
+  - For edits: edit_nodes must include "id" field
+  - For adds: add_nodes must include "label" field
+  - For edges: add_edges must include "source" and "target" fields
+- Preserve valid information from the prior response when possible.
+- If the prior response is unusable, produce a minimal valid plan from the user goal and context.
+- assistant_message must explain the proposed changes clearly, including cost impact if cost_estimate is available.
+- If cost_estimate data is present, prioritize identifying the highest-cost components.
+- If cost_estimate is missing, state your assumptions explicitly in assistant_message.
 """
 
 
@@ -110,6 +137,25 @@ def build_mutation_context(
     }
 
 
+async def _repair_mutation_output(
+    user_goal: str,
+    context: dict[str, Any],
+    invalid_output: str,
+    llm_creds: dict[str, Any] | None,
+) -> str:
+    repair_message = (
+        "Repair this mutation plan output into valid DrawToCloud JSON.\n\n"
+        f"User goal: {user_goal}\n\n"
+        f"Project context:\n{json.dumps(context, indent=2)}\n\n"
+        f"Previous invalid output:\n{invalid_output}"
+    )
+    return await async_complete(
+        messages=[{"role": "user", "content": repair_message}],
+        system=REPAIR_SYSTEM_PROMPT,
+        llm_creds=llm_creds,
+    )
+
+
 async def run_mutation_agent(
     user_goal: str,
     project_state: dict[str, Any],
@@ -134,16 +180,35 @@ async def run_mutation_agent(
     ]
     raw = await async_complete(messages=messages, system=MUTATION_SYSTEM_PROMPT, llm_creds=llm_creds)
 
-    try:
-        payload = _extract_json_object(raw)
-        plan = MutationPlan.model_validate(payload)
-    except Exception as error:
-        raise RuntimeError(
-            "Mutation planner returned an invalid response. "
-            "Please retry with a more specific change request."
-        ) from error
+    for attempt in range(2):
+        try:
+            payload = _extract_json_object(raw)
+            plan = MutationPlan.model_validate(payload)
+            if not plan.assistant_message.strip():
+                raise ValueError("Mutation planner did not return an assistant_message.")
+            return plan
+        except (json.JSONDecodeError, ValueError) as error:
+            logger.warning(
+                "mutation.parse_or_validation_failed attempt=%d error=%s",
+                attempt + 1,
+                str(error),
+            )
+            if attempt == 1:
+                break
+            logger.info("mutation.attempting_repair")
+            raw = await _repair_mutation_output(user_goal, context, raw, llm_creds)
+        except Exception as error:
+            logger.warning(
+                "mutation.unexpected_error attempt=%d error=%s",
+                attempt + 1,
+                str(error),
+            )
+            if attempt == 1:
+                break
+            logger.info("mutation.attempting_repair")
+            raw = await _repair_mutation_output(user_goal, context, raw, llm_creds)
 
-    if not plan.assistant_message.strip():
-        raise RuntimeError("Mutation planner did not return an assistant_message.")
-
-    return plan
+    raise RuntimeError(
+        "Mutation planner returned an invalid response. "
+        "Please retry with a more specific change request."
+    )

--- a/backend/tests/agents/test_mutation_agent.py
+++ b/backend/tests/agents/test_mutation_agent.py
@@ -1,0 +1,157 @@
+import pytest
+from unittest.mock import patch
+
+from agents.mutation_agent import run_mutation_agent
+
+VALID_MUTATION_PLAN = {
+    "assistant_message": "I'll reduce costs by rightsizing the ECS cluster from t3.medium to t3.small, saving approximately $15/month. This is safe because the current utilization is only 20%.",
+    "reasoning": "Current ECS instance is oversized for actual usage",
+    "constraints_respected": ["maintain same AZ coverage"],
+    "diff": {
+        "edit_nodes": [
+            {"id": "ecs_cluster", "data": {"instance_type": "t3.small"}}
+        ]
+    }
+}
+
+PROJECT_STATE_WITH_COST = {
+    "nodes": [
+        {"id": "vpc", "label": "VPC", "category": "network"},
+        {"id": "ecs_cluster", "label": "ECS Cluster", "category": "compute", "data": {"instance_type": "t3.medium"}},
+        {"id": "rds", "label": "RDS PostgreSQL", "category": "database", "data": {"instance_type": "db.t3.medium"}},
+    ],
+    "edges": [
+        {"id": "e1", "source": "alb", "target": "ecs_cluster", "label": "routes to"},
+    ],
+    "cost_estimate": {
+        "monthly_total": 145.50,
+        "items": [
+            {"service": "ECS Cluster", "monthly_cost": 45.00, "cost_drivers": ["instance_type"]},
+            {"service": "RDS PostgreSQL", "monthly_cost": 80.00, "cost_drivers": ["instance_type"]},
+        ]
+    }
+}
+
+PROJECT_STATE_WITHOUT_COST = {
+    "nodes": [
+        {"id": "vpc", "label": "VPC", "category": "network"},
+        {"id": "ecs_cluster", "label": "ECS Cluster", "category": "compute", "data": {"instance_type": "t3.medium"}},
+    ],
+    "edges": [
+        {"id": "e1", "source": "alb", "target": "ecs_cluster", "label": "routes to"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_broad_cost_reduction_request_fails_with_invalid_json():
+    """Test RED: broad cost-reduction request fails with generic error when model returns invalid JSON.
+
+    This test documents the CURRENT broken behavior: the mutation planner raises
+    a generic RuntimeError without any repair attempt when the model returns invalid JSON.
+    After the fix, this should instead trigger the repair mechanism.
+    """
+    with patch("agents.mutation_agent.async_complete", return_value="not json at all"):
+        with pytest.raises(RuntimeError, match="invalid response"):
+            await run_mutation_agent(
+                user_goal="can we make this architecture cheaper",
+                project_state=PROJECT_STATE_WITH_COST,
+            )
+
+
+@pytest.mark.asyncio
+async def test_repair_path_recovers_from_invalid_first_pass():
+    """Test that when model returns invalid JSON on first attempt, repair mechanism recovers.
+
+    This test will FAIL with current implementation (no repair path exists).
+    After fix: should retry with repair LLM call and succeed on second attempt.
+    """
+    responses = iter([
+        "not valid json",
+        '{"assistant_message": "Plan to reduce costs.", "reasoning": "", "diff": {}}',
+    ])
+
+    async def fake_complete(*_args, **_kwargs):
+        return next(responses)
+
+    with patch("agents.mutation_agent.async_complete", side_effect=fake_complete):
+        result = await run_mutation_agent(
+            user_goal="can we make this architecture cheaper",
+            project_state=PROJECT_STATE_WITH_COST,
+        )
+
+    assert result.assistant_message == "Plan to reduce costs."
+    assert result.diff is not None
+
+
+@pytest.mark.asyncio
+async def test_cost_optimization_request_produces_valid_plan_with_changes():
+    """Test that cost-optimization request with cost_estimate produces a plan with concrete changes.
+
+    The plan should have:
+    - non-empty assistant_message referencing cost savings
+    - non-empty diff (has concrete graph changes)
+    """
+    with patch("agents.mutation_agent.async_complete", return_value='{"assistant_message": "I will reduce costs by $15/month by rightsizing ECS from t3.medium to t3.small.", "reasoning": "Current utilization is 20%.", "constraints_respected": [], "diff": {"edit_nodes": [{"id": "ecs_cluster", "data": {"instance_type": "t3.small"}}]}}'):
+        result = await run_mutation_agent(
+            user_goal="can we make this architecture cheaper",
+            project_state=PROJECT_STATE_WITH_COST,
+        )
+
+    assert result.assistant_message.strip() != ""
+    assert "cost" in result.assistant_message.lower() or "sav" in result.assistant_message.lower()
+    assert not result.diff.is_empty()
+    assert len(result.diff.edit_nodes) > 0
+
+
+@pytest.mark.asyncio
+async def test_missing_cost_estimate_does_not_block_plan_generation():
+    """Test that when cost_estimate is None/missing, planner still produces a plan with assumptions.
+
+    The plan should state explicit assumptions in assistant_message rather than failing.
+    """
+    with patch("agents.mutation_agent.async_complete", return_value='{"assistant_message": "Without cost data, I assume standard t3.medium pricing. Please verify actual costs before implementing.", "reasoning": "No cost_estimate provided in project state.", "constraints_respected": [], "diff": {"edit_nodes": [{"id": "ecs_cluster", "data": {"instance_type": "t3.small"}}]}}'):
+        result = await run_mutation_agent(
+            user_goal="can we make this architecture cheaper",
+            project_state=PROJECT_STATE_WITHOUT_COST,
+        )
+
+    assert result.assistant_message.strip() != ""
+    assert "assume" in result.assistant_message.lower() or "without" in result.assistant_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_schema_invalid_json_triggers_repair():
+    """Test that schema-invalid JSON (valid JSON but wrong structure) triggers repair mechanism.
+
+    This tests that valid JSON with missing required fields gets repaired.
+    """
+    responses = iter([
+        '{"some": "invalid schema"}',
+        '{"assistant_message": "Here is the corrected plan.", "reasoning": "", "diff": {}}',
+    ])
+
+    async def fake_complete(*_args, **_kwargs):
+        return next(responses)
+
+    with patch("agents.mutation_agent.async_complete", side_effect=fake_complete):
+        result = await run_mutation_agent(
+            user_goal="can we make this architecture cheaper",
+            project_state=PROJECT_STATE_WITH_COST,
+        )
+
+    assert result.assistant_message == "Here is the corrected plan."
+
+
+@pytest.mark.asyncio
+async def test_mutation_plan_has_non_empty_diff_for_cost_reduction():
+    """Test that cost-reduction mutation plan has non-empty diff."""
+    with patch("agents.mutation_agent.async_complete", return_value='{"assistant_message": "Reduce RDS instance type to db.t3.small saving $40/month.", "reasoning": "RDS is oversized.", "constraints_respected": ["maintain data durability"], "diff": {"edit_nodes": [{"id": "rds", "data": {"instance_type": "db.t3.small"}}]}}'):
+        result = await run_mutation_agent(
+            user_goal="make this architecture cheaper",
+            project_state=PROJECT_STATE_WITH_COST,
+        )
+
+    assert not result.diff.is_empty()
+    assert len(result.diff.edit_nodes) == 1
+    assert result.diff.edit_nodes[0].id == "rds"


### PR DESCRIPTION
## Summary
- Add repair/retry mechanism to mutation_agent.py (up to 2 attempts) - similar to requirements.py
- Add REPAIR_SYSTEM_PROMPT for malformed mutation plan payloads
- Strengthen prompt to handle missing cost_estimate with explicit assumptions
- Add tests for repair path and cost-optimization scenarios

## Problem
Broad architecture-iteration prompts like "can we make this architecture cheaper" were failing with a generic "Mutation planner returned an invalid response" error instead of returning an approvable plan.

## Root Cause
The mutation planner lacked repair/retry logic - when the LLM returned invalid JSON or schema-invalid output, it immediately failed instead of attempting to repair the response.

## Solution
1. Added `_repair_mutation_output()` function to repair malformed mutation plan payloads
2. Modified `run_mutation_agent()` to retry up to 2 times with repair on JSON parse errors or validation failures
3. Updated MUTATION_SYSTEM_PROMPT to explicitly state that missing cost_estimate should result in explicit assumptions stated in assistant_message
4. Added comprehensive tests covering:
   - Repair path recovers from invalid first pass
   - Schema-invalid JSON triggers repair
   - Missing cost_estimate doesn't block plan generation
   - Cost-optimization requests produce valid plans with concrete diffs

## Testing
- All 411 backend tests pass (405 existing + 6 new mutation agent tests)