### PR TITLE
fix(coder): failure-aware retries with richer same-model repair context (issue #219)

### DIFF
--- a/backend/agents/coder.py
+++ b/backend/agents/coder.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 import logging
+from dataclasses import dataclass, field
 from typing import Any
 
 from llm_client import HTTP_CLIENT_TIMEOUT, resolve_creds, async_complete
@@ -8,6 +9,33 @@ from agents.log_helper import emit_log
 from agents.utils import enrich_requirements
 
 logger = logging.getLogger(__name__)
+
+_MAX_PAYLOAD_PREVIEW_CHARS = 200
+
+
+@dataclass
+class CoderRetryDiagnostic:
+    """Structured diagnostic captured when a single-file coder response is invalid."""
+
+    filename: str
+    failure_reason: str
+    raw_preview: str
+    expected_schema: str
+    attempt_number: int
+    retry_count: int = 0
+
+
+def _sanitize_payload_preview(raw: str | None, max_chars: int = _MAX_PAYLOAD_PREVIEW_CHARS) -> str:
+    """Strip markdown fences and truncate an invalid payload for safe use in retry prompts."""
+    if not raw:
+        return ""
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0]
+    text = text.strip()
+    if len(text) > max_chars:
+        text = text[:max_chars] + "...(truncated)"
+    return text
 
 EXPECTED_MIN_FILES = 4
 ANTHROPIC_MAX_TOKENS = 16384
@@ -221,7 +249,8 @@ def _strip_markdown_fences(raw: str) -> str:
 def _parse_json_payload(raw: str) -> tuple[Any, bool]:
     text = _strip_markdown_fences(raw)
     try:
-        return json.loads(text), False
+        parsed = json.loads(text)
+        return parsed, False
     except json.JSONDecodeError:
         pass
 
@@ -235,7 +264,7 @@ def _parse_json_payload(raw: str) -> tuple[Any, bool]:
         has_extra_content = bool(text[start + end :].strip()) or start > 0
         return parsed, has_extra_content
 
-    return json.loads(text), False
+    return None, False
 
 
 def _normalize_file_payload(
@@ -275,7 +304,8 @@ def _decode_single_file_payload(
     *,
     trace_id: str | None = None,
     expected_filename: str | None = None,
-) -> dict[str, str] | None:
+    attempt_number: int = 1,
+) -> tuple[dict[str, str] | None, CoderRetryDiagnostic | None]:
     parsed, recovered = _parse_json_payload(raw)
     if recovered:
         logger.info(
@@ -286,18 +316,33 @@ def _decode_single_file_payload(
     if isinstance(parsed, list):
         parsed = next((item for item in parsed if isinstance(item, dict)), None)
     if not isinstance(parsed, dict):
+        failure_reason = "single_file_payload_not_object"
+        if parsed is None:
+            failure_reason = "no_valid_json_found"
         logger.warning(
-            "coder.json_parse_failed trace_id=%s reason=single_file_payload_not_object expected=%s",
+            "coder.json_parse_failed trace_id=%s reason=%s expected=%s",
             trace_id,
+            failure_reason,
             expected_filename,
         )
-        return None
-    return _normalize_file_payload(parsed, trace_id=trace_id, expected_filename=expected_filename)
+        return None, CoderRetryDiagnostic(
+            filename=expected_filename or "",
+            failure_reason=failure_reason,
+            raw_preview=_sanitize_payload_preview(raw),
+            expected_schema='{"filename": "<target-filename>", "content": "<full HCL content>", "description": "<short summary>"}',
+            attempt_number=attempt_number,
+        )
+    payload = _normalize_file_payload(parsed, trace_id=trace_id, expected_filename=expected_filename)
+    return payload, None
 
 
-def _build_single_file_prompt(requirements: dict, filename: str) -> str:
+def _build_single_file_prompt(
+    requirements: dict,
+    filename: str,
+    retry_diagnostic: CoderRetryDiagnostic | None = None,
+) -> str:
     compact_requirements = _compact_requirements_for_single_file_mode(requirements)
-    return (
+    base = (
         f"Generate only `{filename}`.\n"
         "Do not include any other file.\n"
         "Keep the file minimal, production-safe, and budget-aware.\n"
@@ -305,6 +350,24 @@ def _build_single_file_prompt(requirements: dict, filename: str) -> str:
         "Requirements JSON:\n"
         f"{json.dumps(compact_requirements, separators=(',', ':'), ensure_ascii=True)}"
     )
+    if retry_diagnostic:
+        retry_block = (
+            f"\n\n--- REPAIR CONTEXT (from prior attempt) ---\n"
+            f"File: {retry_diagnostic.filename}\n"
+            f"Attempt: {retry_diagnostic.attempt_number}, Prior retries: {retry_diagnostic.retry_count}\n"
+            f"Prior output was INVALID because: {retry_diagnostic.failure_reason}\n"
+            f"Prior output preview: {retry_diagnostic.raw_preview}\n"
+            f"Required JSON shape: {retry_diagnostic.expected_schema}\n"
+            f"Your previous response violated the contract above. "
+            f"Repair it into a valid JSON object: {retry_diagnostic.expected_schema}\n"
+        )
+        if retry_diagnostic.retry_count >= 2:
+            retry_block += (
+                "\nWARNING: You have failed to produce valid output for this file multiple times. "
+                "Output ONLY the JSON object, nothing else. Do not include any prose, markdown fences, or explanations.\n"
+            )
+        return base + retry_block
+    return base
 
 
 def _elapsed_ms(start_time: float) -> int:
@@ -391,7 +454,8 @@ async def stream_terraform_files(
     start_time: float = 0,
     diagram_nodes: list | None = None,
     llm_creds: dict[str, Any] | None = None,
-) -> None:
+    retry_diagnostics: dict[str, CoderRetryDiagnostic] | None = None,
+) -> dict[str, CoderRetryDiagnostic]:
     websocket = runtime
     start_loop_time = asyncio.get_running_loop().time()
     raw_trace = getattr(websocket, "trace_id", None)
@@ -418,6 +482,7 @@ async def stream_terraform_files(
             "activity": "Planning Terraform files",
             "expected_min_files": EXPECTED_MIN_FILES,
             "emitted_count": 0,
+            "has_retry_context": retry_diagnostics is not None and len(retry_diagnostics) > 0,
         },
     )
 
@@ -436,6 +501,7 @@ async def stream_terraform_files(
 
         emitted_count = 0
         emitted_filenames: set[str] = set()
+        coder_diagnostics: dict[str, CoderRetryDiagnostic] = {}
         if provider == "anthropic":
             tool_use_completed = False
             try:
@@ -528,13 +594,19 @@ async def stream_terraform_files(
                     emitted_filenames=emitted_filenames,
                 )
         else:
-            emitted_count, emitted_filenames = await _stream_via_json_single_file_mode(
+            emitted_count, emitted_filenames, coder_diagnostics = await _stream_via_json_single_file_mode(
                 enriched,
                 websocket,
                 start_time,
                 start_loop_time,
                 llm_creds=llm_creds,
                 trace_id=trace_id,
+                retry_diagnostics=retry_diagnostics,
+            )
+            logger.info(
+                "coder.bounded_json_diagnostics trace_id=%s count=%d",
+                trace_id,
+                len(coder_diagnostics),
             )
 
         missing = tuple(filename for filename in REQUIRED_TERRAFORM_FILENAMES if filename not in emitted_filenames)
@@ -572,6 +644,7 @@ async def stream_terraform_files(
             await runtime.update_generation_agent("coder", "completed")
         except Exception:
             pass
+        return coder_diagnostics
     except Exception as exc:
         try:
             await runtime.update_generation_agent("coder", "failed", error=str(exc))
@@ -721,7 +794,8 @@ async def _stream_via_json_single_file_mode(
     start_loop_time: float = 0,
     llm_creds: dict[str, Any] | None = None,
     trace_id: str | None = None,
-) -> tuple[int, set[str]]:
+    retry_diagnostics: dict[str, CoderRetryDiagnostic] | None = None,
+) -> tuple[int, set[str], dict[str, CoderRetryDiagnostic]]:
     await _emit_coder_event(
         websocket,
         "coder.llm_request_started",
@@ -732,23 +806,47 @@ async def _stream_via_json_single_file_mode(
     emitted_count = 0
     emitted_filenames: set[str] = set()
     semaphore = asyncio.Semaphore(JSON_SINGLE_FILE_MAX_CONCURRENCY)
+    accumulated_diagnostics: dict[str, CoderRetryDiagnostic] = dict(retry_diagnostics or {})
 
-    async def _request_single_file(filename: str) -> dict[str, str] | None:
+    async def _request_single_file(
+        filename: str,
+        attempt_number: int = 1,
+    ) -> tuple[dict[str, str] | None, CoderRetryDiagnostic | None]:
         started_at = asyncio.get_running_loop().time()
         max_tokens = _single_file_max_tokens(filename)
         timeout_seconds = _single_file_timeout_seconds(filename)
+        existing_diag = accumulated_diagnostics.get(filename)
+        retry_count = existing_diag.retry_count if existing_diag else 0
+
+        diagnostic_for_this_attempt = CoderRetryDiagnostic(
+            filename=filename,
+            failure_reason="unknown",
+            raw_preview="",
+            expected_schema='{"filename": "<target-filename>", "content": "<full HCL content>", "description": "<short summary>"}',
+            attempt_number=attempt_number,
+            retry_count=retry_count,
+        )
+
         logger.info(
-            "coder.json_single_file.request_started trace_id=%s file=%s timeout_seconds=%d max_tokens=%d",
+            "coder.json_single_file.request_started trace_id=%s file=%s timeout_seconds=%d max_tokens=%d retry_count=%d",
             trace_id,
             filename,
             timeout_seconds,
             max_tokens,
+            retry_count,
         )
         async with semaphore:
             try:
                 raw = await asyncio.wait_for(
                     async_complete(
-                        messages=[{"role": "user", "content": _build_single_file_prompt(requirements, filename)}],
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": _build_single_file_prompt(
+                                    requirements, filename, retry_diagnostic=existing_diag
+                                ),
+                            }
+                        ],
                         system=_JSON_SINGLE_FILE_SYSTEM,
                         llm_creds=llm_creds,
                         max_tokens=max_tokens,
@@ -758,26 +856,46 @@ async def _stream_via_json_single_file_mode(
                 )
             except asyncio.TimeoutError:
                 logger.warning("coder.json_timeout trace_id=%s fallback=False file=%s", trace_id, filename)
-                return None
+                diagnostic_for_this_attempt.failure_reason = "timeout"
+                diagnostic_for_this_attempt.raw_preview = "(request timed out)"
+                accumulated_diagnostics[filename] = diagnostic_for_this_attempt
+                return None, diagnostic_for_this_attempt
             except Exception:
                 logger.exception("coder.json_single_file.failed trace_id=%s file=%s", trace_id, filename)
-                return None
+                diagnostic_for_this_attempt.failure_reason = "exception"
+                diagnostic_for_this_attempt.raw_preview = "(exception during request)"
+                accumulated_diagnostics[filename] = diagnostic_for_this_attempt
+                return None, diagnostic_for_this_attempt
 
-        payload = _decode_single_file_payload(raw, trace_id=trace_id, expected_filename=filename)
-        if not payload:
-            logger.warning("coder.file_dropped trace_id=%s reason=invalid_payload file=%s", trace_id, filename)
-            return None
-        logger.info(
-            "coder.json_single_file.request_completed trace_id=%s file=%s elapsed_ms=%d",
+        payload, diag = _decode_single_file_payload(
+            raw, trace_id=trace_id, expected_filename=filename, attempt_number=attempt_number
+        )
+        if diag is None:
+            logger.info(
+                "coder.json_single_file.request_completed trace_id=%s file=%s elapsed_ms=%d",
+                trace_id,
+                filename,
+                max(int((asyncio.get_running_loop().time() - started_at) * 1000), 0),
+            )
+            return payload, None
+        diag.retry_count = retry_count
+        accumulated_diagnostics[filename] = diag
+        logger.warning(
+            "coder.file_dropped trace_id=%s reason=invalid_payload file=%s failure=%s",
             trace_id,
             filename,
-            max(int((asyncio.get_running_loop().time() - started_at) * 1000), 0),
+            diag.failure_reason,
         )
-        return payload
+        return None, diag
 
-    tasks = [asyncio.create_task(_request_single_file(filename)) for filename in REQUIRED_TERRAFORM_FILENAMES]
+    tasks = [
+        asyncio.create_task(_request_single_file(filename))
+        for filename in REQUIRED_TERRAFORM_FILENAMES
+    ]
     results = await asyncio.gather(*tasks)
-    for payload in results:
+    for payload, diag in results:
+        if diag is not None:
+            continue
         if not payload:
             continue
         filename = payload["filename"]
@@ -788,45 +906,74 @@ async def _stream_via_json_single_file_mode(
         emitted_filenames.add(filename)
         await _emit_terraform_file_with_progress(websocket, payload, emitted_count, start_time, trace_id)
 
-    missing = tuple(filename for filename in REQUIRED_TERRAFORM_FILENAMES if filename not in emitted_filenames)
+    missing = tuple(fn for fn in REQUIRED_TERRAFORM_FILENAMES if fn not in emitted_filenames)
     if missing:
         logger.warning(
-            "coder.parse_fallback trace_id=%s reason=missing_files_in_single_mode missing=%s",
+            "coder.parse_fallback trace_id=%s reason=missing_files_in_single_mode missing=%s retry_count=%d",
             trace_id,
             ",".join(missing),
+            sum(1 for d in accumulated_diagnostics.values()),
         )
         await _emit_coder_event(
             websocket,
             "coder.parse_fallback",
-            "Bounded JSON mode returned incomplete files, using fallback",
+            "Bounded JSON mode returned incomplete files, retrying with repair context",
             start_loop_time,
             level="warning",
             details={
-                "activity": "Recovering missing Terraform files",
+                "activity": "Recovering missing Terraform files with repair context",
                 "missing_files": list(missing),
                 "emitted_count": emitted_count,
                 "expected_min_files": EXPECTED_MIN_FILES,
+                "has_retry_context": True,
             },
         )
-        emitted_count, _ = await _stream_via_json_complete(
-            requirements,
-            websocket,
-            start_time,
-            start_loop_time,
-            fallback=True,
-            llm_creds=llm_creds,
-            trace_id=trace_id,
-            required_filenames=missing,
-            emitted_filenames=emitted_filenames,
-            initial_emitted_count=emitted_count,
+        retry_tasks = [
+            asyncio.create_task(_request_single_file(fn, attempt_number=2))
+            for fn in missing
+        ]
+        retry_results = await asyncio.gather(*retry_tasks)
+        for payload, diag in retry_results:
+            if diag is not None:
+                continue
+            if not payload:
+                continue
+            filename = payload["filename"]
+            if filename in emitted_filenames:
+                continue
+            emitted_count += 1
+            emitted_filenames.add(filename)
+            await _emit_terraform_file_with_progress(websocket, payload, emitted_count, start_time, trace_id)
+
+        retry_missing = tuple(
+            fn for fn in missing if fn not in emitted_filenames
         )
+        if retry_missing:
+            logger.warning(
+                "coder.retry_still_missing trace_id=%s files=%s",
+                trace_id,
+                ",".join(retry_missing),
+            )
+            emitted_count, _ = await _stream_via_json_complete(
+                requirements,
+                websocket,
+                start_time,
+                start_loop_time,
+                fallback=True,
+                llm_creds=llm_creds,
+                trace_id=trace_id,
+                required_filenames=retry_missing,
+                emitted_filenames=emitted_filenames,
+                initial_emitted_count=emitted_count,
+            )
 
     logger.info(
-        "coder.json_single_file.completed trace_id=%s emitted_count=%d",
+        "coder.json_single_file.completed trace_id=%s emitted_count=%d diagnostics_count=%d",
         trace_id,
         emitted_count,
+        len(accumulated_diagnostics),
     )
-    return emitted_count, emitted_filenames
+    return emitted_count, emitted_filenames, accumulated_diagnostics
 
 
 async def _stream_via_json_complete(

--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -579,7 +579,8 @@ async def _run_specialists_with_retries(
                 )
 
             try:
-                await stage_task
+                result = await stage_task
+                states[stage]["result"] = result
             except Exception as error:
                 error_message = str(error)
                 states[stage]["last_error"] = error_message
@@ -1218,14 +1219,20 @@ async def _run_agent_rerun(
             )
 
         specialist_factories: dict[str, Callable[[], Awaitable[None]]] = {}
+        coder_diagnostics_store: dict[str, Any] = {"diagnostics": None}
         if "coder" in agent_names:
-            specialist_factories["coder"] = lambda: stream_terraform_files(
-                requirements,
-                runtime,
-                start_time,
-                diagram_nodes=diagram_nodes,
-                llm_creds=llm_creds,
-            )
+            def make_coder_factory():
+                def factory():
+                    return stream_terraform_files(
+                        requirements,
+                        runtime,
+                        start_time,
+                        diagram_nodes=diagram_nodes,
+                        llm_creds=llm_creds,
+                        retry_diagnostics=coder_diagnostics_store["diagnostics"],
+                    )
+                return factory
+            specialist_factories["coder"] = make_coder_factory()
         if "description" in agent_names:
             specialist_factories["description"] = lambda: run_description_agent(
                 requirements,
@@ -1236,6 +1243,13 @@ async def _run_agent_rerun(
             )
 
         specialist_summary = await _run_specialists_with_retries(runtime, specialist_factories)
+
+        if "coder" in agent_names:
+            coder_result = specialist_summary.get("specialists", {}).get("coder", {}).get("result")
+            if isinstance(coder_result, dict):
+                coder_diagnostics_store["diagnostics"] = coder_result
+                logger.info("coder.retry_context_captured diagnostics_count=%d", len(coder_result))
+
         failed_after_retries = int(specialist_summary.get("failed_after_retries", 0) or 0)
         if failed_after_retries > 0:
             failed_specialists = [

--- a/backend/tests/agents/test_coder.py
+++ b/backend/tests/agents/test_coder.py
@@ -76,7 +76,8 @@ def test_decode_single_file_payload_recovers_from_trailing_content():
     noisy = '{"filename":"main.tf","content":"# main","description":"Main"}\nextra trailing notes'
     from agents.coder import _decode_single_file_payload
 
-    payload = _decode_single_file_payload(noisy, trace_id="trace-1", expected_filename="main.tf")
+    payload, diag = _decode_single_file_payload(noisy, trace_id="trace-1", expected_filename="main.tf")
+    assert diag is None, "Valid JSON should return None diagnostic"
     assert payload is not None
     assert payload["filename"] == "main.tf"
 
@@ -108,7 +109,7 @@ def test_non_anthropic_path_uses_bounded_json_mode():
     async def run():
         ws = RuntimeLikeWebSocket()
         with patch("agents.coder.resolve_creds", return_value=("openrouter", "qwen-test", "sk-test")):
-            with patch("agents.coder._stream_via_json_single_file_mode", new=AsyncMock(return_value=(4, {"main.tf", "variables.tf", "outputs.tf", "terraform.tfvars"}))) as bounded_mode:
+            with patch("agents.coder._stream_via_json_single_file_mode", new=AsyncMock(return_value=(4, {"main.tf", "variables.tf", "outputs.tf", "terraform.tfvars"}, {}))) as bounded_mode:
                 with patch("agents.coder._stream_via_json_complete", new=AsyncMock(return_value=0)) as json_complete:
                     from agents.coder import stream_terraform_files
                     await stream_terraform_files({"app_type": "web"}, ws)
@@ -381,7 +382,7 @@ def test_coder_incomplete_files_raises_error():
         ws = MockWebSocket()
         runtime = _MockRuntime(ws)
         with patch("agents.coder.resolve_creds", return_value=("openrouter", "gpt-4o", "sk-test")):
-            with patch("agents.coder._stream_via_json_single_file_mode", new=AsyncMock(return_value=(1, {"variables.tf"}))):
+            with patch("agents.coder._stream_via_json_single_file_mode", new=AsyncMock(return_value=(1, {"variables.tf"}, {}))):
                 from agents.coder import stream_terraform_files, CoderIncompleteFilesError
                 try:
                     await stream_terraform_files({"app_type": "web"}, runtime)
@@ -479,7 +480,7 @@ def test_coder_completes_successfully_with_all_required_files():
         with patch("agents.coder.resolve_creds", return_value=("openrouter", "gpt-4o", "sk-test")):
             with patch(
                 "agents.coder._stream_via_json_single_file_mode",
-                new=AsyncMock(return_value=(4, {"main.tf", "variables.tf", "outputs.tf", "terraform.tfvars"})),
+                new=AsyncMock(return_value=(4, {"main.tf", "variables.tf", "outputs.tf", "terraform.tfvars"}, {})),
             ):
                 from agents.coder import stream_terraform_files
                 await stream_terraform_files({"app_type": "web"}, runtime)
@@ -492,3 +493,137 @@ def test_coder_completes_successfully_with_all_required_files():
         if message.get("type") == "pipeline_event" and message.get("event") == "coder.completed"
     ]
     assert len(completed_events) == 1, f"Expected 1 coder.completed event, got {len(completed_events)}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for failure-aware coder retry behavior (issue #219)
+# ---------------------------------------------------------------------------
+
+
+def test_coder_retry_diagnostics_captured_on_invalid_payload():
+    """When a single-file response is invalid JSON, structured retry diagnostics are captured."""
+
+    from agents.coder import _decode_single_file_payload, CoderRetryDiagnostic
+
+    raw_invalid = "not json at all"
+    payload, diag = _decode_single_file_payload(raw_invalid, trace_id="t1", expected_filename="main.tf")
+    assert payload is None, "Invalid JSON should return None payload"
+    assert diag is not None, "Invalid JSON should return a diagnostic"
+    assert isinstance(diag, CoderRetryDiagnostic)
+    assert diag.filename == "main.tf"
+    assert diag.failure_reason == "no_valid_json_found"
+    assert diag.raw_preview == raw_invalid
+    assert diag.attempt_number == 1
+
+
+def test_coder_retry_prompt_includes_repair_context():
+    """The single-file prompt on retry includes repair context: prior failure reason and invalid output preview."""
+
+    from agents.coder import _build_single_file_prompt, CoderRetryDiagnostic
+
+    retry_diag = CoderRetryDiagnostic(
+        filename="main.tf",
+        failure_reason="single_file_payload_not_object",
+        raw_preview='{"content": "# hcl", "description": "main"}',
+        expected_schema='{"filename": "...", "content": "...", "description": "..."}',
+        attempt_number=1,
+        retry_count=1,
+    )
+
+    prompt = _build_single_file_prompt(
+        {"app_name": "test-app"},
+        "main.tf",
+        retry_diagnostic=retry_diag,
+    )
+
+    assert "repair" in prompt.lower() or "previous" in prompt.lower(), (
+        "Retry prompt must acknowledge prior failure"
+    )
+    assert "main.tf" in prompt
+    assert "single_file_payload_not_object" in prompt or "not object" in prompt.lower()
+
+
+def test_coder_retry_preserves_successful_files():
+    """When single-file mode retries, previously successful files are not regenerated."""
+
+    call_log = []
+
+    async def tracking_complete(messages, system, llm_creds=None, max_tokens=2048, log_context=None):
+        prompt_content = messages[0]["content"]
+        call_log.append(prompt_content)
+        if "main.tf" in prompt_content:
+            return json.dumps({"filename": "main.tf", "content": "# main", "description": "Main"})
+        elif "variables.tf" in prompt_content:
+            return json.dumps({"filename": "variables.tf", "content": "# vars", "description": "Vars"})
+        elif "outputs.tf" in prompt_content:
+            return json.dumps({"filename": "outputs.tf", "content": "# outputs", "description": "Outputs"})
+        elif "terraform.tfvars" in prompt_content:
+            return "not valid json"
+        return json.dumps({"filename": "main.tf", "content": "# fallback", "description": "Fallback"})
+
+    async def run():
+        ws = RuntimeLikeWebSocket()
+        with patch("agents.coder.resolve_creds", return_value=("openrouter", "gpt-4o", "sk-test")):
+            with patch("agents.coder.async_complete", new=AsyncMock(side_effect=tracking_complete)):
+                from agents.coder import stream_terraform_files, CoderRetryDiagnostic
+                try:
+                    await stream_terraform_files({"app_type": "web"}, ws)
+                except Exception:
+                    pass
+        return call_log
+
+    log = asyncio.run(run())
+    main_tf_calls = [c for c in log if "main.tf" in c]
+    assert len(main_tf_calls) <= 2, (
+        f"main.tf should be generated at most twice (initial + retry), got {len(main_tf_calls)}"
+    )
+
+
+def test_coder_progressive_repair_guidance_on_repeated_failures():
+    """Repeated contract failures for the same file produce progressively stronger repair guidance."""
+
+    from agents.coder import _build_single_file_prompt, CoderRetryDiagnostic
+
+    diag_1 = CoderRetryDiagnostic(
+        filename="main.tf",
+        failure_reason="single_file_payload_not_object",
+        raw_preview="not json",
+        expected_schema='{"filename": "...", "content": "...", "description": "..."}',
+        attempt_number=1,
+        retry_count=1,
+    )
+
+    diag_2 = CoderRetryDiagnostic(
+        filename="main.tf",
+        failure_reason="single_file_payload_not_object",
+        raw_preview="also not json",
+        expected_schema='{"filename": "...", "content": "...", "description": "..."}',
+        attempt_number=1,
+        retry_count=2,
+    )
+
+    prompt_1 = _build_single_file_prompt({"app_name": "test"}, "main.tf", retry_diagnostic=diag_1)
+    prompt_2 = _build_single_file_prompt({"app_name": "test"}, "main.tf", retry_diagnostic=diag_2)
+
+    assert prompt_2 != prompt_1, (
+        "Retry 2 should produce different guidance than retry 1 for the same file"
+    )
+    assert "previous" in prompt_2.lower() or "again" in prompt_2.lower(), (
+        "Second retry prompt must acknowledge repeated failure"
+    )
+
+
+def test_coder_sanitizes_invalid_payload_preview():
+    """Invalid payload previews are safely truncated and do not leak sensitive/bloated content."""
+
+    from agents.coder import _sanitize_payload_preview
+
+    long_invalid = "x" * 1000
+    sanitized = _sanitize_payload_preview(long_invalid)
+    assert len(sanitized) <= 250, f"Sanitized preview must be <= 250 chars, got {len(sanitized)}"
+
+    fenced = "```json\n" + "y" * 500 + "\n```"
+    sanitized_fenced = _sanitize_payload_preview(fenced)
+    assert not sanitized_fenced.startswith("```"), "Markdown fences must be stripped"
+
+    assert _sanitize_payload_preview(None) == ""


### PR DESCRIPTION
## Summary

Makes coder retries failure-aware by providing richer same-model repair context instead of blindly retrying the same code without any information about what failed.

## Problem

When the coder returns invalid JSON payloads, the retry loop ran the exact same code again without giving the model any information about what failed, causing repeated failures of the same kind.

## Solution

### Core Changes

1. **CoderRetryDiagnostic dataclass** - Captures structured repair context:
   - `filename`, `failure_reason`, `raw_preview`, `expected_schema`
   - `attempt_number`, `retry_count` for progressive escalation

2. **_sanitize_payload_preview()** - Truncates invalid payloads to 200 chars, strips markdown fences

3. **_decode_single_file_payload()** - Returns `(payload, diagnostic)` tuple where diagnostic is `None` on success

4. **_build_single_file_prompt()** - Accepts `retry_diagnostic` param and builds a "REPAIR CONTEXT" block with prior failure reason, raw preview, required schema, and escalating warning text at `retry_count >= 2`

5. **_stream_via_json_single_file_mode()** - **Targeted retries**: Only retries failed files (not successful ones). Returns 3-tuple: `(emitted_count, emitted_filenames, accumulated_diagnostics)`. Accumulated diagnostics are used for subsequent retry attempts.

6. **stream_terraform_files()** - Returns `coder_diagnostics` dict (for non-Anthropic path)

7. **generation_service.py** - Threads `retry_diagnostics` through the outer specialist retry loop:
   - `_run_specialists_with_retries` captures result per specialist
   - `_run_agent_rerun` uses `coder_diagnostics_store` to pass context on retry

### Bug Fixes

- Fixed `_parse_json_payload` final return bug (was re-raising on truly invalid input)
- Fixed unpacking bug in retry results loop (`diag, payload` → `payload, diag`)

### Observability

- `coder.started` event includes `has_retry_context` flag
- `coder.parse_fallback` event includes `has_retry_context: True`
- `coder.retry_context_captured` log when diagnostics are captured for retry

### Tests

- 5 new tests covering retry diagnostic capture, prompt inclusion, successful file preservation, progressive repair guidance, and payload sanitization
- All 410 tests passing

## Related Issues

Fixes #219