### PR TITLE
refactor(frontend): redesign chat panel — Quiet Operator

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -2,13 +2,12 @@
 
 import { Send } from "lucide-react";
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
-import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
-import { colorForCategory } from "@/lib/categoryColors";
 import { shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
 import { useChat } from "./Chat/useChat";
 import ChatHeader from "./Chat/ChatHeader";
 import ChatStarterPills from "./Chat/ChatStarterPills";
+import ChatMessageList from "./Chat/ChatMessageList";
 
 const DEBUG_CHAT_STATES = false;
 
@@ -144,127 +143,19 @@ export default function Chat({
             isTyping={isTyping}
           />
         )}
-        {messages.map((msg, i) => (
-          <div key={i} className="flex flex-col gap-2">
-            {msg.selectedNodes && msg.selectedNodes.length > 0 && (
-              <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
-                <div className="max-w-[85%] flex flex-wrap gap-1.5">
-                  {msg.selectedNodes.map((node) => (
-                    <div
-                      key={`${i}-${node.id}`}
-                      className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
-                    >
-                      <span
-                        className="w-2 h-2 rounded-full"
-                        style={{ backgroundColor: colorForCategory(node.category) }}
-                        aria-hidden
-                      />
-                      <span>{node.label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-            <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
-              <div
-                className={`max-w-[85%] rounded-xl px-3 py-2 text-sm ${
-                  msg.role === "user"
-                    ? "bg-blue-600 text-white"
-                    : "bg-gray-700 text-gray-100"
-                }`}
-              >
-                {msg.role === "assistant" ? (
-                  <ChatMessageMarkdown content={msg.content} />
-                ) : (
-                  msg.content
-                )}
-              </div>
-            </div>
-            {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && (
-              <div className="ml-1 mt-2 mb-2 p-3 bg-gray-900 border border-gray-700 rounded-lg text-xs">
-                <div className="font-semibold text-gray-200 mb-2">Planned Changes</div>
-                {msg.planMeta.details.nodes_added && msg.planMeta.details.nodes_added.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-green-400">Add:</span>{" "}
-                    {msg.planMeta.details.nodes_added.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.nodes_edited && msg.planMeta.details.nodes_edited.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-blue-400">Edit:</span>{" "}
-                    {msg.planMeta.details.nodes_edited.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.nodes_deleted && msg.planMeta.details.nodes_deleted.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-red-400">Delete:</span>{" "}
-                    {msg.planMeta.details.nodes_deleted.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.edges_added && msg.planMeta.details.edges_added.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-green-400">Add connections:</span>{" "}
-                    {msg.planMeta.details.edges_added.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.edges_deleted && msg.planMeta.details.edges_deleted.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-red-400">Remove connections:</span>{" "}
-                    {msg.planMeta.details.edges_deleted.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.reasoning && (
-                  <div className="mt-2 text-gray-400 italic">{msg.planMeta.details.reasoning}</div>
-                )}
-              </div>
-            )}
-            {msg.planReady && onAcceptAndGenerate && i === latestPlanMessageIndex && (
-              <div className="flex justify-start pl-1">
-                <button
-                  type="button"
-                  onClick={() => onAcceptAndGenerate(msg.planMeta?.plan_id)}
-                  disabled={approveDisabled}
-                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
-                >
-                  {approveDisabled
-                    ? "Applying update..."
-                    : "Implement plan"}
-                </button>
-              </div>
-            )}
-            {msg.role === "assistant" &&
-              onBudgetRecoveryAction &&
-              msg.budgetRecovery?.status === "pending" &&
-              i === latestPendingBudgetRecoveryMessageIndex && (
-                <div className="flex justify-start gap-2 pl-1">
-                  <button
-                    type="button"
-                    onClick={() => onBudgetRecoveryAction("accept")}
-                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
-                    className="px-3 py-1.5 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-gray-100 transition-colors"
-                  >
-                    Accept
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onBudgetRecoveryAction("retry")}
-                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
-                    className="px-3 py-1.5 rounded-lg border border-blue-600 bg-blue-600 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-white transition-colors"
-                  >
-                    Retry
-                  </button>
-                </div>
-              )}
-          </div>
-        ))}
-        {isTyping && (
-          <div className="flex justify-start">
-            <div className="max-w-[85%] rounded-xl px-3 py-2 text-sm bg-gray-700 text-gray-100">
-              <span className="animate-pulse">...</span>
-            </div>
-          </div>
-        )}
-        <div ref={bottomRef} />
+        <ChatMessageList
+          messages={messages}
+          latestPlanMessageIndex={latestPlanMessageIndex}
+          latestPendingBudgetRecoveryIndex={latestPendingBudgetRecoveryMessageIndex}
+          isTyping={isTyping}
+          bottomRef={bottomRef}
+          onAcceptAndGenerate={onAcceptAndGenerate}
+          approveDisabled={approveDisabled}
+          onBudgetRecoveryAction={onBudgetRecoveryAction}
+          budgetRecoveryDisabled={budgetRecoveryDisabled}
+          disabled={disabled}
+          readOnly={readOnly}
+        />
       </div>
       <div className="border-t border-gray-700">
         {!readOnly && selectedNodes.length > 0 && onDeselectNode && (

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,13 +1,12 @@
 "use client";
 
+import { useState, useRef, useEffect } from "react";
+import { Send } from "lucide-react";
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
-import { shouldShowChatStarters } from "@/lib/chatStarters";
+import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
+import { colorForCategory } from "@/lib/categoryColors";
+import { DEFAULT_CHAT_STARTERS, shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
-import { useChat } from "./Chat/useChat";
-import ChatHeader from "./Chat/ChatHeader";
-import ChatStarterPills from "./Chat/ChatStarterPills";
-import ChatMessageList from "./Chat/ChatMessageList";
-import ChatComposer from "./Chat/ChatComposer";
 
 interface ChatProps {
   onSend: (message: string, selectedNodeIds: string[]) => void;
@@ -26,7 +25,7 @@ interface ChatProps {
 
 export default function Chat({
   onSend,
-  messages: propMessages,
+  messages,
   disabled = false,
   isTyping = false,
   disabledReason = null,
@@ -38,70 +37,249 @@ export default function Chat({
   selectedNodes = [],
   onDeselectNode,
 }: ChatProps) {
-  const messages = propMessages;
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
+  const COMPOSER_MIN_HEIGHT_PX = 40;
+  const COMPOSER_MAX_HEIGHT_PX = 160;
+  const latestPlanMessageIndex = messages.reduce<number>(
+    (latest, msg, index) => (msg.role === "assistant" && msg.planReady ? index : latest),
+    -1
+  );
+  const latestPendingBudgetRecoveryMessageIndex = (() => {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const msg = messages[i];
+      if (msg.role !== "assistant" || !msg.budgetRecovery) continue;
+      const status = msg.budgetRecovery.status.trim().toLowerCase();
+      if (status === "pending") return i;
+      if (status === "accepted" || status === "retry_started" || status === "resolved" || status === "cancelled") {
+        return -1;
+      }
+    }
+    return -1;
+  })();
 
-  const {
-    input,
-    setInput,
-    textareaRef,
-    bottomRef,
-    submitMessage,
-    handleSubmit,
-    handleTextareaKeyDown,
-    onCompositionStart,
-    onCompositionEnd,
-    latestPlanMessageIndex,
-    latestPendingBudgetRecoveryMessageIndex,
-  } = useChat({
-    messages,
-    onSend,
-    selectedNodes,
-    disabled,
-    readOnly,
-    isTyping,
-  });
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = `${COMPOSER_MIN_HEIGHT_PX}px`;
+    const nextHeight = Math.min(Math.max(textarea.scrollHeight, COMPOSER_MIN_HEIGHT_PX), COMPOSER_MAX_HEIGHT_PX);
+    textarea.style.height = `${nextHeight}px`;
+    textarea.style.overflowY = textarea.scrollHeight > COMPOSER_MAX_HEIGHT_PX ? "auto" : "hidden";
+  }, [input]);
+
+  function submitMessage() {
+    if (disabled || readOnly) return;
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    onSend(trimmed, selectedNodes.map((node) => node.id));
+    setInput("");
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    submitMessage();
+  }
+
+  function handleTextareaKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    if (isComposingRef.current || e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
+    e.preventDefault();
+    submitMessage();
+  }
 
   return (
     <div className="flex flex-col h-full bg-gray-900 border-r border-gray-700">
-      <ChatHeader isTyping={isTyping} readOnly={readOnly} disabled={disabled} />
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
         {shouldShowChatStarters({ readOnly, messageCount: messages.length }) && (
-          <ChatStarterPills
-            onSend={(starter) => onSend(starter, [])}
-            disabled={disabled}
-            isTyping={isTyping}
-          />
+          <div className="space-y-2">
+            <p className="text-xs text-gray-400">Try one of these:</p>
+            <div className="flex flex-wrap gap-2">
+              {DEFAULT_CHAT_STARTERS.map((starter) => (
+                <button
+                  key={starter}
+                  type="button"
+                  onClick={() => onSend(starter, [])}
+                  disabled={disabled || isTyping}
+                  className="rounded-full border border-gray-700 bg-gray-800/70 px-3 py-1.5 text-xs text-gray-200 hover:bg-gray-700/80 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
+                >
+                  {starter}
+                </button>
+              ))}
+            </div>
+          </div>
         )}
-        <ChatMessageList
-          messages={messages}
-          latestPlanMessageIndex={latestPlanMessageIndex}
-          latestPendingBudgetRecoveryIndex={latestPendingBudgetRecoveryMessageIndex}
-          isTyping={isTyping}
-          bottomRef={bottomRef}
-          onAcceptAndGenerate={onAcceptAndGenerate}
-          approveDisabled={approveDisabled}
-          onBudgetRecoveryAction={onBudgetRecoveryAction}
-          budgetRecoveryDisabled={budgetRecoveryDisabled}
-          disabled={disabled}
-          readOnly={readOnly}
-        />
+        {messages.map((msg, i) => (
+          <div key={i} className="flex flex-col gap-2">
+            {msg.selectedNodes && msg.selectedNodes.length > 0 && (
+              <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+                <div className="max-w-[85%] flex flex-wrap gap-1.5">
+                  {msg.selectedNodes.map((node) => (
+                    <div
+                      key={`${i}-${node.id}`}
+                      className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
+                    >
+                      <span
+                        className="w-2 h-2 rounded-full"
+                        style={{ backgroundColor: colorForCategory(node.category) }}
+                        aria-hidden
+                      />
+                      <span>{node.label}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+              <div
+                className={`max-w-[85%] rounded-xl px-3 py-2 text-sm ${
+                  msg.role === "user"
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-700 text-gray-100"
+                }`}
+              >
+                {msg.role === "assistant" ? (
+                  <ChatMessageMarkdown content={msg.content} />
+                ) : (
+                  msg.content
+                )}
+              </div>
+            </div>
+            {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && (
+              <div className="ml-1 mt-2 mb-2 p-3 bg-gray-900 border border-gray-700 rounded-lg text-xs">
+                <div className="font-semibold text-gray-200 mb-2">Planned Changes</div>
+                {msg.planMeta.details.nodes_added && msg.planMeta.details.nodes_added.length > 0 && (
+                  <div className="mb-1">
+                    <span className="text-green-400">Add:</span>{" "}
+                    {msg.planMeta.details.nodes_added.map((n) => n.label).join(", ")}
+                  </div>
+                )}
+                {msg.planMeta.details.nodes_edited && msg.planMeta.details.nodes_edited.length > 0 && (
+                  <div className="mb-1">
+                    <span className="text-blue-400">Edit:</span>{" "}
+                    {msg.planMeta.details.nodes_edited.map((n) => n.label).join(", ")}
+                  </div>
+                )}
+                {msg.planMeta.details.nodes_deleted && msg.planMeta.details.nodes_deleted.length > 0 && (
+                  <div className="mb-1">
+                    <span className="text-red-400">Delete:</span>{" "}
+                    {msg.planMeta.details.nodes_deleted.map((n) => n.label).join(", ")}
+                  </div>
+                )}
+                {msg.planMeta.details.edges_added && msg.planMeta.details.edges_added.length > 0 && (
+                  <div className="mb-1">
+                    <span className="text-green-400">Add connections:</span>{" "}
+                    {msg.planMeta.details.edges_added.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
+                  </div>
+                )}
+                {msg.planMeta.details.edges_deleted && msg.planMeta.details.edges_deleted.length > 0 && (
+                  <div className="mb-1">
+                    <span className="text-red-400">Remove connections:</span>{" "}
+                    {msg.planMeta.details.edges_deleted.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
+                  </div>
+                )}
+                {msg.planMeta.details.reasoning && (
+                  <div className="mt-2 text-gray-400 italic">{msg.planMeta.details.reasoning}</div>
+                )}
+              </div>
+            )}
+            {msg.planReady && onAcceptAndGenerate && i === latestPlanMessageIndex && (
+              <div className="flex justify-start pl-1">
+                <button
+                  type="button"
+                  onClick={() => onAcceptAndGenerate(msg.planMeta?.plan_id)}
+                  disabled={approveDisabled}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  {approveDisabled
+                    ? "Applying update..."
+                    : "Implement plan"}
+                </button>
+              </div>
+            )}
+            {msg.role === "assistant" &&
+              onBudgetRecoveryAction &&
+              msg.budgetRecovery?.status === "pending" &&
+              i === latestPendingBudgetRecoveryMessageIndex && (
+                <div className="flex justify-start gap-2 pl-1">
+                  <button
+                    type="button"
+                    onClick={() => onBudgetRecoveryAction("accept")}
+                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
+                    className="px-3 py-1.5 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-gray-100 transition-colors"
+                  >
+                    Accept
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onBudgetRecoveryAction("retry")}
+                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
+                    className="px-3 py-1.5 rounded-lg border border-blue-600 bg-blue-600 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-white transition-colors"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+          </div>
+        ))}
+        {isTyping && (
+          <div className="flex justify-start">
+            <div className="max-w-[85%] rounded-xl px-3 py-2 text-sm bg-gray-700 text-gray-100">
+              <span className="animate-pulse">...</span>
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
       </div>
       <div className="border-t border-gray-700">
         {!readOnly && selectedNodes.length > 0 && onDeselectNode && (
           <ChatSelectionChips selectedNodes={selectedNodes} onDeselect={onDeselectNode} />
         )}
-        <ChatComposer
-          input={input}
-          textareaRef={textareaRef}
-          disabled={disabled}
-          disabledReason={disabledReason}
-          readOnly={readOnly}
-          onChange={setInput}
-          onKeyDown={handleTextareaKeyDown}
-          onCompositionStart={onCompositionStart}
-          onCompositionEnd={onCompositionEnd}
-          onSubmit={handleSubmit}
-        />
+        <form onSubmit={handleSubmit} className="px-4 py-3">
+          {readOnly ? (
+            <p className="text-xs text-gray-400">Sign in to start designing</p>
+          ) : (
+            <div className="flex items-end gap-2">
+              <textarea
+                ref={textareaRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleTextareaKeyDown}
+                onCompositionStart={() => {
+                  isComposingRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  isComposingRef.current = false;
+                }}
+                disabled={disabled}
+                rows={1}
+                placeholder={
+                  disabled
+                    ? "Chat is temporarily unavailable"
+                    : "e.g. What database am I using?"
+                }
+                className="flex-1 bg-gray-800 text-white text-sm rounded-lg px-3 py-2 border border-gray-600 focus:outline-none focus:border-blue-500 placeholder-gray-500 resize-none leading-5 max-h-40"
+              />
+              <button
+                type="submit"
+                disabled={disabled || !input.trim()}
+                className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-colors"
+              >
+                <Send size={16} />
+              </button>
+            </div>
+          )}
+          {disabledReason && (
+            <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>
+          )}
+        </form>
       </div>
     </div>
   );

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
 import { Send } from "lucide-react";
+
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
-import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
-import { colorForCategory } from "@/lib/categoryColors";
-import { DEFAULT_CHAT_STARTERS, shouldShowChatStarters } from "@/lib/chatStarters";
+import ChatHeader from "@/components/Chat/ChatHeader";
+import ChatMessageList from "@/components/Chat/ChatMessageList";
+import ChatStarterPills from "@/components/Chat/ChatStarterPills";
+import { useChat } from "@/components/Chat/useChat";
+import { shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
 
 interface ChatProps {
@@ -37,206 +39,50 @@ export default function Chat({
   selectedNodes = [],
   onDeselectNode,
 }: ChatProps) {
-  const [input, setInput] = useState("");
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const isComposingRef = useRef(false);
-  const COMPOSER_MIN_HEIGHT_PX = 40;
-  const COMPOSER_MAX_HEIGHT_PX = 160;
-  const latestPlanMessageIndex = messages.reduce<number>(
-    (latest, msg, index) => (msg.role === "assistant" && msg.planReady ? index : latest),
-    -1
-  );
-  const latestPendingBudgetRecoveryMessageIndex = (() => {
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const msg = messages[i];
-      if (msg.role !== "assistant" || !msg.budgetRecovery) continue;
-      const status = msg.budgetRecovery.status.trim().toLowerCase();
-      if (status === "pending") return i;
-      if (status === "accepted" || status === "retry_started" || status === "resolved" || status === "cancelled") {
-        return -1;
-      }
-    }
-    return -1;
-  })();
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    textarea.style.height = `${COMPOSER_MIN_HEIGHT_PX}px`;
-    const nextHeight = Math.min(Math.max(textarea.scrollHeight, COMPOSER_MIN_HEIGHT_PX), COMPOSER_MAX_HEIGHT_PX);
-    textarea.style.height = `${nextHeight}px`;
-    textarea.style.overflowY = textarea.scrollHeight > COMPOSER_MAX_HEIGHT_PX ? "auto" : "hidden";
-  }, [input]);
-
-  function submitMessage() {
-    if (disabled || readOnly) return;
-    const trimmed = input.trim();
-    if (!trimmed) return;
-    onSend(trimmed, selectedNodes.map((node) => node.id));
-    setInput("");
-  }
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    submitMessage();
-  }
-
-  function handleTextareaKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key !== "Enter" || e.shiftKey) return;
-    if (isComposingRef.current || e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
-
-    e.preventDefault();
-    submitMessage();
-  }
+  const {
+    input,
+    setInput,
+    textareaRef,
+    bottomRef,
+    handleSubmit,
+    handleTextareaKeyDown,
+    onCompositionStart,
+    onCompositionEnd,
+    latestPlanMessageIndex,
+    latestPendingBudgetRecoveryMessageIndex,
+  } = useChat({
+    messages,
+    onSend,
+    selectedNodes,
+    disabled,
+    readOnly,
+    isTyping,
+  });
 
   return (
-    <div className="flex flex-col h-full bg-gray-900 border-r border-gray-700">
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+    <div className="flex h-full flex-col border-r border-gray-700 bg-gray-900">
+      <ChatHeader isTyping={isTyping} readOnly={readOnly} disabled={disabled} />
+      <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
         {shouldShowChatStarters({ readOnly, messageCount: messages.length }) && (
-          <div className="space-y-2">
-            <p className="text-xs text-gray-400">Try one of these:</p>
-            <div className="flex flex-wrap gap-2">
-              {DEFAULT_CHAT_STARTERS.map((starter) => (
-                <button
-                  key={starter}
-                  type="button"
-                  onClick={() => onSend(starter, [])}
-                  disabled={disabled || isTyping}
-                  className="rounded-full border border-gray-700 bg-gray-800/70 px-3 py-1.5 text-xs text-gray-200 hover:bg-gray-700/80 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
-                >
-                  {starter}
-                </button>
-              ))}
-            </div>
-          </div>
+          <ChatStarterPills
+            onSend={(starter) => onSend(starter, [])}
+            disabled={disabled}
+            isTyping={isTyping}
+          />
         )}
-        {messages.map((msg, i) => (
-          <div key={i} className="flex flex-col gap-2">
-            {msg.selectedNodes && msg.selectedNodes.length > 0 && (
-              <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
-                <div className="max-w-[85%] flex flex-wrap gap-1.5">
-                  {msg.selectedNodes.map((node) => (
-                    <div
-                      key={`${i}-${node.id}`}
-                      className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
-                    >
-                      <span
-                        className="w-2 h-2 rounded-full"
-                        style={{ backgroundColor: colorForCategory(node.category) }}
-                        aria-hidden
-                      />
-                      <span>{node.label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-            <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
-              <div
-                className={`max-w-[85%] rounded-xl px-3 py-2 text-sm ${
-                  msg.role === "user"
-                    ? "bg-blue-600 text-white"
-                    : "bg-gray-700 text-gray-100"
-                }`}
-              >
-                {msg.role === "assistant" ? (
-                  <ChatMessageMarkdown content={msg.content} />
-                ) : (
-                  msg.content
-                )}
-              </div>
-            </div>
-            {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && (
-              <div className="ml-1 mt-2 mb-2 p-3 bg-gray-900 border border-gray-700 rounded-lg text-xs">
-                <div className="font-semibold text-gray-200 mb-2">Planned Changes</div>
-                {msg.planMeta.details.nodes_added && msg.planMeta.details.nodes_added.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-green-400">Add:</span>{" "}
-                    {msg.planMeta.details.nodes_added.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.nodes_edited && msg.planMeta.details.nodes_edited.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-blue-400">Edit:</span>{" "}
-                    {msg.planMeta.details.nodes_edited.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.nodes_deleted && msg.planMeta.details.nodes_deleted.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-red-400">Delete:</span>{" "}
-                    {msg.planMeta.details.nodes_deleted.map((n) => n.label).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.edges_added && msg.planMeta.details.edges_added.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-green-400">Add connections:</span>{" "}
-                    {msg.planMeta.details.edges_added.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.edges_deleted && msg.planMeta.details.edges_deleted.length > 0 && (
-                  <div className="mb-1">
-                    <span className="text-red-400">Remove connections:</span>{" "}
-                    {msg.planMeta.details.edges_deleted.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
-                  </div>
-                )}
-                {msg.planMeta.details.reasoning && (
-                  <div className="mt-2 text-gray-400 italic">{msg.planMeta.details.reasoning}</div>
-                )}
-              </div>
-            )}
-            {msg.planReady && onAcceptAndGenerate && i === latestPlanMessageIndex && (
-              <div className="flex justify-start pl-1">
-                <button
-                  type="button"
-                  onClick={() => onAcceptAndGenerate(msg.planMeta?.plan_id)}
-                  disabled={approveDisabled}
-                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
-                >
-                  {approveDisabled
-                    ? "Applying update..."
-                    : "Implement plan"}
-                </button>
-              </div>
-            )}
-            {msg.role === "assistant" &&
-              onBudgetRecoveryAction &&
-              msg.budgetRecovery?.status === "pending" &&
-              i === latestPendingBudgetRecoveryMessageIndex && (
-                <div className="flex justify-start gap-2 pl-1">
-                  <button
-                    type="button"
-                    onClick={() => onBudgetRecoveryAction("accept")}
-                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
-                    className="px-3 py-1.5 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-gray-100 transition-colors"
-                  >
-                    Accept
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onBudgetRecoveryAction("retry")}
-                    disabled={disabled || isTyping || readOnly || budgetRecoveryDisabled}
-                    className="px-3 py-1.5 rounded-lg border border-blue-600 bg-blue-600 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-white transition-colors"
-                  >
-                    Retry
-                  </button>
-                </div>
-              )}
-          </div>
-        ))}
-        {isTyping && (
-          <div className="flex justify-start">
-            <div className="max-w-[85%] rounded-xl px-3 py-2 text-sm bg-gray-700 text-gray-100">
-              <span className="animate-pulse">...</span>
-            </div>
-          </div>
-        )}
-        <div ref={bottomRef} />
+        <ChatMessageList
+          messages={messages}
+          latestPlanMessageIndex={latestPlanMessageIndex}
+          latestPendingBudgetRecoveryIndex={latestPendingBudgetRecoveryMessageIndex}
+          isTyping={isTyping}
+          bottomRef={bottomRef}
+          onAcceptAndGenerate={onAcceptAndGenerate}
+          approveDisabled={approveDisabled}
+          onBudgetRecoveryAction={onBudgetRecoveryAction}
+          budgetRecoveryDisabled={budgetRecoveryDisabled}
+          disabled={disabled}
+          readOnly={readOnly}
+        />
       </div>
       <div className="border-t border-gray-700">
         {!readOnly && selectedNodes.length > 0 && onDeselectNode && (
@@ -252,33 +98,23 @@ export default function Chat({
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleTextareaKeyDown}
-                onCompositionStart={() => {
-                  isComposingRef.current = true;
-                }}
-                onCompositionEnd={() => {
-                  isComposingRef.current = false;
-                }}
+                onCompositionStart={onCompositionStart}
+                onCompositionEnd={onCompositionEnd}
                 disabled={disabled}
                 rows={1}
-                placeholder={
-                  disabled
-                    ? "Chat is temporarily unavailable"
-                    : "e.g. What database am I using?"
-                }
-                className="flex-1 bg-gray-800 text-white text-sm rounded-lg px-3 py-2 border border-gray-600 focus:outline-none focus:border-blue-500 placeholder-gray-500 resize-none leading-5 max-h-40"
+                placeholder={disabled ? "Chat is temporarily unavailable" : "e.g. What database am I using?"}
+                className="max-h-40 flex-1 resize-none rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-sm leading-5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
               />
               <button
                 type="submit"
                 disabled={disabled || !input.trim()}
-                className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-colors"
+                className="rounded-lg bg-blue-600 p-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-700"
               >
                 <Send size={16} />
               </button>
             </div>
           )}
-          {disabledReason && (
-            <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>
-          )}
+          {disabledReason && <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>}
         </form>
       </div>
     </div>

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -4,9 +4,11 @@ import { Send } from "lucide-react";
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
 import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
 import { colorForCategory } from "@/lib/categoryColors";
-import { DEFAULT_CHAT_STARTERS, shouldShowChatStarters } from "@/lib/chatStarters";
+import { shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
 import { useChat } from "./Chat/useChat";
+import ChatHeader from "./Chat/ChatHeader";
+import ChatStarterPills from "./Chat/ChatStarterPills";
 
 const DEBUG_CHAT_STATES = false;
 
@@ -133,24 +135,14 @@ export default function Chat({
 
   return (
     <div className="flex flex-col h-full bg-gray-900 border-r border-gray-700">
+      <ChatHeader isTyping={isTyping} readOnly={readOnly} disabled={disabled} />
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
         {shouldShowChatStarters({ readOnly, messageCount: messages.length }) && (
-          <div className="space-y-2">
-            <p className="text-xs text-gray-400">Try one of these:</p>
-            <div className="flex flex-wrap gap-2">
-              {DEFAULT_CHAT_STARTERS.map((starter) => (
-                <button
-                  key={starter}
-                  type="button"
-                  onClick={() => onSend(starter, [])}
-                  disabled={disabled || isTyping}
-                  className="rounded-full border border-gray-700 bg-gray-800/70 px-3 py-1.5 text-xs text-gray-200 hover:bg-gray-700/80 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
-                >
-                  {starter}
-                </button>
-              ))}
-            </div>
-          </div>
+          <ChatStarterPills
+            onSend={(starter) => onSend(starter, [])}
+            disabled={disabled}
+            isTyping={isTyping}
+          />
         )}
         {messages.map((msg, i) => (
           <div key={i} className="flex flex-col gap-2">

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,12 +1,83 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
 import { Send } from "lucide-react";
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
 import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
 import { colorForCategory } from "@/lib/categoryColors";
 import { DEFAULT_CHAT_STARTERS, shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
+import { useChat } from "./Chat/useChat";
+
+const DEBUG_CHAT_STATES = false;
+
+const DEBUG_MESSAGES: Record<string, CanvasMessage[]> = {
+  empty: [],
+  userAssistant: [
+    { role: "user", content: "What database am I using?" },
+    { role: "assistant", content: "You're using RDS PostgreSQL with an ElastiCache Redis cluster for caching." },
+  ],
+  longMarkdown: [
+    { role: "user", content: "Explain the architecture" },
+    {
+      role: "assistant",
+      content: `# Architecture Overview
+
+## Components
+
+1. **VPC** - Virtual Private Cloud with public and private subnets
+2. **ECS Cluster** - Container orchestration with Fargate
+3. **RDS PostgreSQL** - Managed relational database
+4. **ElastiCache** - Redis for session storage
+5. **S3 Bucket** - Static asset storage
+
+## Data Flow
+
+\`\`\`
+Client → CloudFront → ALB → ECS Containers → RDS/ElastiCache/S3
+\`\`\`
+
+## Scaling
+
+- Auto-scaling based on CPU utilization
+- Multi-AZ deployment for high availability
+`,
+    },
+  ],
+  planReady: [
+    { role: "user", content: "Add a Redis cache" },
+    {
+      role: "assistant",
+      content: "I'll add Redis to your architecture.",
+      planReady: true,
+      executionMode: "node_patch",
+      planMeta: {
+        plan_id: "plan-123",
+        type: "node_patch",
+        details: {
+          nodes_added: [{ id: "redis", label: "ElastiCache Redis", category: "database" }],
+          nodes_edited: [],
+          nodes_deleted: [],
+          edges_added: [{ from: "ecs", to: "redis", label: "caches" }],
+          edges_deleted: [],
+          reasoning: "Adding Redis for session caching to improve response times.",
+        },
+      },
+    },
+  ],
+  budgetRecovery: [
+    { role: "user", content: "Generate more components" },
+    {
+      role: "assistant",
+      content: "Your estimated monthly cost has exceeded the budget cap.",
+      budgetRecovery: {
+        status: "pending",
+        budgetCap: 100,
+        estimatedTotal: 145.5,
+        overage: 45.5,
+      },
+    },
+  ],
+};
 
 interface ChatProps {
   onSend: (message: string, selectedNodeIds: string[]) => void;
@@ -25,7 +96,7 @@ interface ChatProps {
 
 export default function Chat({
   onSend,
-  messages,
+  messages: propMessages,
   disabled = false,
   isTyping = false,
   disabledReason = null,
@@ -37,63 +108,28 @@ export default function Chat({
   selectedNodes = [],
   onDeselectNode,
 }: ChatProps) {
-  const [input, setInput] = useState("");
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const isComposingRef = useRef(false);
-  const COMPOSER_MIN_HEIGHT_PX = 40;
-  const COMPOSER_MAX_HEIGHT_PX = 160;
-  const latestPlanMessageIndex = messages.reduce<number>(
-    (latest, msg, index) => (msg.role === "assistant" && msg.planReady ? index : latest),
-    -1
-  );
-  const latestPendingBudgetRecoveryMessageIndex = (() => {
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const msg = messages[i];
-      if (msg.role !== "assistant" || !msg.budgetRecovery) continue;
-      const status = msg.budgetRecovery.status.trim().toLowerCase();
-      if (status === "pending") return i;
-      if (status === "accepted" || status === "retry_started" || status === "resolved" || status === "cancelled") {
-        return -1;
-      }
-    }
-    return -1;
-  })();
+  const messages = DEBUG_CHAT_STATES ? (DEBUG_MESSAGES.longMarkdown ?? []) : propMessages;
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    textarea.style.height = `${COMPOSER_MIN_HEIGHT_PX}px`;
-    const nextHeight = Math.min(Math.max(textarea.scrollHeight, COMPOSER_MIN_HEIGHT_PX), COMPOSER_MAX_HEIGHT_PX);
-    textarea.style.height = `${nextHeight}px`;
-    textarea.style.overflowY = textarea.scrollHeight > COMPOSER_MAX_HEIGHT_PX ? "auto" : "hidden";
-  }, [input]);
-
-  function submitMessage() {
-    if (disabled || readOnly) return;
-    const trimmed = input.trim();
-    if (!trimmed) return;
-    onSend(trimmed, selectedNodes.map((node) => node.id));
-    setInput("");
-  }
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    submitMessage();
-  }
-
-  function handleTextareaKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key !== "Enter" || e.shiftKey) return;
-    if (isComposingRef.current || e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
-
-    e.preventDefault();
-    submitMessage();
-  }
+  const {
+    input,
+    setInput,
+    textareaRef,
+    bottomRef,
+    submitMessage,
+    handleSubmit,
+    handleTextareaKeyDown,
+    onCompositionStart,
+    onCompositionEnd,
+    latestPlanMessageIndex,
+    latestPendingBudgetRecoveryMessageIndex,
+  } = useChat({
+    messages,
+    onSend,
+    selectedNodes,
+    disabled,
+    readOnly,
+    isTyping,
+  });
 
   return (
     <div className="flex flex-col h-full bg-gray-900 border-r border-gray-700">
@@ -252,12 +288,8 @@ export default function Chat({
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleTextareaKeyDown}
-                onCompositionStart={() => {
-                  isComposingRef.current = true;
-                }}
-                onCompositionEnd={() => {
-                  isComposingRef.current = false;
-                }}
+                onCompositionStart={onCompositionStart}
+                onCompositionEnd={onCompositionEnd}
                 disabled={disabled}
                 rows={1}
                 placeholder={

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Send } from "lucide-react";
 import ChatSelectionChips, { type ChatSelectionNode } from "@/components/ChatSelectionChips";
 import { shouldShowChatStarters } from "@/lib/chatStarters";
 import type { CanvasMessage } from "@/lib/projects";
@@ -8,6 +7,7 @@ import { useChat } from "./Chat/useChat";
 import ChatHeader from "./Chat/ChatHeader";
 import ChatStarterPills from "./Chat/ChatStarterPills";
 import ChatMessageList from "./Chat/ChatMessageList";
+import ChatComposer from "./Chat/ChatComposer";
 
 const DEBUG_CHAT_STATES = false;
 
@@ -161,40 +161,18 @@ export default function Chat({
         {!readOnly && selectedNodes.length > 0 && onDeselectNode && (
           <ChatSelectionChips selectedNodes={selectedNodes} onDeselect={onDeselectNode} />
         )}
-        <form onSubmit={handleSubmit} className="px-4 py-3">
-          {readOnly ? (
-            <p className="text-xs text-gray-400">Sign in to start designing</p>
-          ) : (
-            <div className="flex items-end gap-2">
-              <textarea
-                ref={textareaRef}
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleTextareaKeyDown}
-                onCompositionStart={onCompositionStart}
-                onCompositionEnd={onCompositionEnd}
-                disabled={disabled}
-                rows={1}
-                placeholder={
-                  disabled
-                    ? "Chat is temporarily unavailable"
-                    : "e.g. What database am I using?"
-                }
-                className="flex-1 bg-gray-800 text-white text-sm rounded-lg px-3 py-2 border border-gray-600 focus:outline-none focus:border-blue-500 placeholder-gray-500 resize-none leading-5 max-h-40"
-              />
-              <button
-                type="submit"
-                disabled={disabled || !input.trim()}
-                className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-colors"
-              >
-                <Send size={16} />
-              </button>
-            </div>
-          )}
-          {disabledReason && (
-            <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>
-          )}
-        </form>
+        <ChatComposer
+          input={input}
+          textareaRef={textareaRef}
+          disabled={disabled}
+          disabledReason={disabledReason}
+          readOnly={readOnly}
+          onChange={setInput}
+          onKeyDown={handleTextareaKeyDown}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
+          onSubmit={handleSubmit}
+        />
       </div>
     </div>
   );

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -9,77 +9,6 @@ import ChatStarterPills from "./Chat/ChatStarterPills";
 import ChatMessageList from "./Chat/ChatMessageList";
 import ChatComposer from "./Chat/ChatComposer";
 
-const DEBUG_CHAT_STATES = false;
-
-const DEBUG_MESSAGES: Record<string, CanvasMessage[]> = {
-  empty: [],
-  userAssistant: [
-    { role: "user", content: "What database am I using?" },
-    { role: "assistant", content: "You're using RDS PostgreSQL with an ElastiCache Redis cluster for caching." },
-  ],
-  longMarkdown: [
-    { role: "user", content: "Explain the architecture" },
-    {
-      role: "assistant",
-      content: `# Architecture Overview
-
-## Components
-
-1. **VPC** - Virtual Private Cloud with public and private subnets
-2. **ECS Cluster** - Container orchestration with Fargate
-3. **RDS PostgreSQL** - Managed relational database
-4. **ElastiCache** - Redis for session storage
-5. **S3 Bucket** - Static asset storage
-
-## Data Flow
-
-\`\`\`
-Client → CloudFront → ALB → ECS Containers → RDS/ElastiCache/S3
-\`\`\`
-
-## Scaling
-
-- Auto-scaling based on CPU utilization
-- Multi-AZ deployment for high availability
-`,
-    },
-  ],
-  planReady: [
-    { role: "user", content: "Add a Redis cache" },
-    {
-      role: "assistant",
-      content: "I'll add Redis to your architecture.",
-      planReady: true,
-      executionMode: "node_patch",
-      planMeta: {
-        plan_id: "plan-123",
-        type: "node_patch",
-        details: {
-          nodes_added: [{ id: "redis", label: "ElastiCache Redis", category: "database" }],
-          nodes_edited: [],
-          nodes_deleted: [],
-          edges_added: [{ from: "ecs", to: "redis", label: "caches" }],
-          edges_deleted: [],
-          reasoning: "Adding Redis for session caching to improve response times.",
-        },
-      },
-    },
-  ],
-  budgetRecovery: [
-    { role: "user", content: "Generate more components" },
-    {
-      role: "assistant",
-      content: "Your estimated monthly cost has exceeded the budget cap.",
-      budgetRecovery: {
-        status: "pending",
-        budgetCap: 100,
-        estimatedTotal: 145.5,
-        overage: 45.5,
-      },
-    },
-  ],
-};
-
 interface ChatProps {
   onSend: (message: string, selectedNodeIds: string[]) => void;
   messages: CanvasMessage[];
@@ -109,7 +38,7 @@ export default function Chat({
   selectedNodes = [],
   onDeselectNode,
 }: ChatProps) {
-  const messages = DEBUG_CHAT_STATES ? (DEBUG_MESSAGES.longMarkdown ?? []) : propMessages;
+  const messages = propMessages;
 
   const {
     input,

--- a/frontend/components/Chat/ChatBudgetRecoveryCard.tsx
+++ b/frontend/components/Chat/ChatBudgetRecoveryCard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface ChatBudgetRecoveryCardProps {
+  onBudgetRecoveryAction?: (action: "accept" | "retry") => void;
+  budgetRecoveryDisabled?: boolean;
+  disabled?: boolean;
+  isTyping?: boolean;
+  readOnly?: boolean;
+}
+
+export default function ChatBudgetRecoveryCard({
+  onBudgetRecoveryAction,
+  budgetRecoveryDisabled,
+  disabled,
+  isTyping,
+  readOnly,
+}: ChatBudgetRecoveryCardProps) {
+  const isActionDisabled = disabled || isTyping || readOnly || budgetRecoveryDisabled;
+
+  return (
+    <div className="flex justify-start gap-2 pl-1 mt-1">
+      <button
+        type="button"
+        onClick={() => onBudgetRecoveryAction?.("accept")}
+        disabled={isActionDisabled}
+        className="px-3 py-1.5 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-gray-100 transition-colors"
+      >
+        Accept
+      </button>
+      <button
+        type="button"
+        onClick={() => onBudgetRecoveryAction?.("retry")}
+        disabled={isActionDisabled}
+        className="px-3 py-1.5 rounded-lg border border-blue-600 bg-blue-600 hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 text-xs text-white transition-colors"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatComposer.tsx
+++ b/frontend/components/Chat/ChatComposer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Send } from "lucide-react";
+
+interface ChatComposerProps {
+  input: string;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  disabled?: boolean;
+  disabledReason?: string | null;
+  readOnly?: boolean;
+  onChange: (value: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onCompositionStart: () => void;
+  onCompositionEnd: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export default function ChatComposer({
+  input,
+  textareaRef,
+  disabled = false,
+  disabledReason = null,
+  readOnly = false,
+  onChange,
+  onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
+  onSubmit,
+}: ChatComposerProps) {
+  if (readOnly) {
+    return (
+      <p className="text-xs text-gray-400 px-4 py-3">Sign in to start designing</p>
+    );
+  }
+
+  return (
+    <div>
+      <form onSubmit={onSubmit} className="px-4 py-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={onKeyDown}
+            onCompositionStart={onCompositionStart}
+            onCompositionEnd={onCompositionEnd}
+            disabled={disabled}
+            rows={1}
+            placeholder={
+              disabled
+                ? "Chat is temporarily unavailable"
+                : "e.g. What database am I using?"
+            }
+            className="flex-1 bg-gray-800 text-white text-sm rounded-lg px-3 py-2 border border-gray-600 focus:outline-none focus:border-blue-500 placeholder-gray-500 resize-none leading-5 max-h-40"
+          />
+          <button
+            type="submit"
+            disabled={disabled || !input.trim()}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-colors"
+            aria-label="Send message"
+          >
+            <Send size={16} />
+          </button>
+        </div>
+        {disabledReason && (
+          <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatHeader.tsx
+++ b/frontend/components/Chat/ChatHeader.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import { Bot } from "lucide-react";
+
+import {
+  CHAT_HEADER_SUBTITLE,
+  CHAT_HEADER_TITLE,
+  getChatHeaderStatusLabel,
+} from "./chatHeaderContent";
+
 interface ChatHeaderProps {
   isTyping: boolean;
   readOnly: boolean;
@@ -7,33 +15,33 @@ interface ChatHeaderProps {
 }
 
 export default function ChatHeader({ isTyping, readOnly, disabled }: ChatHeaderProps) {
-  let statusLabel: string | null = null;
-  if (isTyping) {
-    statusLabel = "thinking…";
-  } else if (readOnly) {
-    statusLabel = "sign in to chat";
-  } else if (disabled) {
-    statusLabel = "unavailable";
-  }
+  const statusLabel = getChatHeaderStatusLabel({ isTyping, readOnly, disabled });
 
   return (
-    <div className="px-4 py-3 border-b border-gray-700 flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-gray-400 tracking-wide">
-          draw<span className="text-white">to</span>cloud
-        </span>
-        <span className="text-xs text-gray-500">—</span>
-        <span className="text-xs text-gray-500">Describe your infrastructure</span>
+    <div className="border-b border-gray-700 px-4 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-700 bg-gray-800/80 text-gray-400">
+            <Bot className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-medium text-gray-200">{CHAT_HEADER_TITLE}</span>
+            <span className="truncate text-xs text-gray-500">{CHAT_HEADER_SUBTITLE}</span>
+          </div>
+        </div>
+        {statusLabel && (
+          <span
+            className={[
+              "ml-3 shrink-0 text-xs text-gray-500",
+              isTyping ? "animate-pulse" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {statusLabel}
+          </span>
+        )}
       </div>
-      {statusLabel && (
-        <span
-          className={`text-xs ${
-            isTyping ? "text-gray-400 animate-pulse" : "text-gray-500"
-          }`}
-        >
-          {statusLabel}
-        </span>
-      )}
     </div>
   );
 }

--- a/frontend/components/Chat/ChatHeader.tsx
+++ b/frontend/components/Chat/ChatHeader.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+interface ChatHeaderProps {
+  isTyping: boolean;
+  readOnly: boolean;
+  disabled: boolean;
+}
+
+export default function ChatHeader({ isTyping, readOnly, disabled }: ChatHeaderProps) {
+  let statusLabel: string | null = null;
+  if (isTyping) {
+    statusLabel = "thinking…";
+  } else if (readOnly) {
+    statusLabel = "sign in to chat";
+  } else if (disabled) {
+    statusLabel = "unavailable";
+  }
+
+  return (
+    <div className="px-4 py-3 border-b border-gray-700 flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-gray-400 tracking-wide">
+          draw<span className="text-white">to</span>cloud
+        </span>
+        <span className="text-xs text-gray-500">—</span>
+        <span className="text-xs text-gray-500">Describe your infrastructure</span>
+      </div>
+      {statusLabel && (
+        <span
+          className={`text-xs ${
+            isTyping ? "text-gray-400 animate-pulse" : "text-gray-500"
+          }`}
+        >
+          {statusLabel}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatMessageBubble.tsx
+++ b/frontend/components/Chat/ChatMessageBubble.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import ChatMessageMarkdown from "@/components/ChatMessageMarkdown";
+
+interface ChatMessageBubbleProps {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function ChatMessageBubble({ role, content }: ChatMessageBubbleProps) {
+  const isUser = role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[85%] rounded-xl px-3 py-2 text-sm ${
+          isUser ? "bg-blue-600 text-white" : "bg-gray-700 text-gray-100"
+        }`}
+      >
+        {role === "assistant" ? (
+          <ChatMessageMarkdown content={content} />
+        ) : (
+          content
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatMessageList.tsx
+++ b/frontend/components/Chat/ChatMessageList.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { RefObject } from "react";
+
 import type { CanvasMessage } from "@/lib/projects";
 import ChatTimelineItem from "./ChatTimelineItem";
 
@@ -8,13 +10,12 @@ interface ChatMessageListProps {
   latestPlanMessageIndex: number;
   latestPendingBudgetRecoveryIndex: number;
   isTyping: boolean;
-  bottomRef: React.RefObject<HTMLDivElement>;
+  bottomRef: RefObject<HTMLDivElement>;
   onAcceptAndGenerate?: (planId?: string) => void;
   approveDisabled?: boolean;
   onBudgetRecoveryAction?: (action: "accept" | "retry") => void;
   budgetRecoveryDisabled?: boolean;
   disabled?: boolean;
-  isTyping?: boolean;
   readOnly?: boolean;
 }
 

--- a/frontend/components/Chat/ChatMessageList.tsx
+++ b/frontend/components/Chat/ChatMessageList.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { CanvasMessage } from "@/lib/projects";
+import ChatTimelineItem from "./ChatTimelineItem";
+
+interface ChatMessageListProps {
+  messages: CanvasMessage[];
+  latestPlanMessageIndex: number;
+  latestPendingBudgetRecoveryIndex: number;
+  isTyping: boolean;
+  bottomRef: React.RefObject<HTMLDivElement>;
+  onAcceptAndGenerate?: (planId?: string) => void;
+  approveDisabled?: boolean;
+  onBudgetRecoveryAction?: (action: "accept" | "retry") => void;
+  budgetRecoveryDisabled?: boolean;
+  disabled?: boolean;
+  isTyping?: boolean;
+  readOnly?: boolean;
+}
+
+export default function ChatMessageList({
+  messages,
+  latestPlanMessageIndex,
+  latestPendingBudgetRecoveryIndex,
+  isTyping,
+  bottomRef,
+  onAcceptAndGenerate,
+  approveDisabled,
+  onBudgetRecoveryAction,
+  budgetRecoveryDisabled,
+  disabled,
+  readOnly,
+}: ChatMessageListProps) {
+  return (
+    <>
+      {messages.map((msg, i) => (
+        <ChatTimelineItem
+          key={i}
+          msg={msg}
+          index={i}
+          latestPlanMessageIndex={latestPlanMessageIndex}
+          latestPendingBudgetRecoveryIndex={latestPendingBudgetRecoveryIndex}
+          onAcceptAndGenerate={onAcceptAndGenerate}
+          approveDisabled={approveDisabled}
+          onBudgetRecoveryAction={onBudgetRecoveryAction}
+          budgetRecoveryDisabled={budgetRecoveryDisabled}
+          disabled={disabled}
+          isTyping={isTyping}
+          readOnly={readOnly}
+        />
+      ))}
+      {isTyping && (
+        <div className="flex justify-start">
+          <div className="max-w-[85%] rounded-xl px-3 py-2 text-sm bg-gray-700 text-gray-100">
+            <span className="animate-pulse">...</span>
+          </div>
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </>
+  );
+}

--- a/frontend/components/Chat/ChatPlanCard.tsx
+++ b/frontend/components/Chat/ChatPlanCard.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { CanvasMessage } from "@/lib/projects";
+
+interface ChatPlanCardProps {
+  msg: CanvasMessage;
+  onAcceptAndGenerate?: (planId?: string) => void;
+  approveDisabled?: boolean;
+}
+
+export default function ChatPlanCard({
+  msg,
+  onAcceptAndGenerate,
+  approveDisabled,
+}: ChatPlanCardProps) {
+  const details = msg.planMeta?.details;
+  if (!details) return null;
+
+  return (
+    <div className="ml-1 mt-2 mb-2 p-3 bg-gray-900 border border-gray-700 rounded-lg text-xs">
+      <div className="font-semibold text-gray-200 mb-2">Planned Changes</div>
+
+      {details.nodes_added && details.nodes_added.length > 0 && (
+        <div className="mb-1">
+          <span className="text-green-400">Add:</span>{" "}
+          {details.nodes_added.map((n) => n.label).join(", ")}
+        </div>
+      )}
+      {details.nodes_edited && details.nodes_edited.length > 0 && (
+        <div className="mb-1">
+          <span className="text-blue-400">Edit:</span>{" "}
+          {details.nodes_edited.map((n) => n.label).join(", ")}
+        </div>
+      )}
+      {details.nodes_deleted && details.nodes_deleted.length > 0 && (
+        <div className="mb-1">
+          <span className="text-red-400">Delete:</span>{" "}
+          {details.nodes_deleted.map((n) => n.label).join(", ")}
+        </div>
+      )}
+      {details.edges_added && details.edges_added.length > 0 && (
+        <div className="mb-1">
+          <span className="text-green-400">Add connections:</span>{" "}
+          {details.edges_added.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
+        </div>
+      )}
+      {details.edges_deleted && details.edges_deleted.length > 0 && (
+        <div className="mb-1">
+          <span className="text-red-400">Remove connections:</span>{" "}
+          {details.edges_deleted.map((e) => e.label || `${e.from} → ${e.to}`).join(", ")}
+        </div>
+      )}
+      {details.reasoning && (
+        <div className="mt-2 text-gray-400 italic">{details.reasoning}</div>
+      )}
+
+      {onAcceptAndGenerate && (
+        <div className="flex justify-start pl-1 mt-3">
+          <button
+            type="button"
+            onClick={() => onAcceptAndGenerate(msg.planMeta?.plan_id)}
+            disabled={approveDisabled}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            {approveDisabled ? "Applying update..." : "Implement plan"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatStarterPills.tsx
+++ b/frontend/components/Chat/ChatStarterPills.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { DEFAULT_CHAT_STARTERS } from "@/lib/chatStarters";
+
+interface ChatStarterPillsProps {
+  onSend: (message: string) => void;
+  disabled: boolean;
+  isTyping: boolean;
+}
+
+export default function ChatStarterPills({
+  onSend,
+  disabled,
+  isTyping,
+}: ChatStarterPillsProps) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-500">Try one of these:</p>
+      <div className="flex flex-wrap gap-2">
+        {DEFAULT_CHAT_STARTERS.map((starter) => (
+          <button
+            key={starter}
+            type="button"
+            onClick={() => onSend(starter)}
+            disabled={disabled || isTyping}
+            className="rounded-full border border-gray-700/50 bg-gray-800/50 px-3 py-1.5 text-xs text-gray-200
+              hover:bg-gray-700/70 hover:border-gray-600
+              focus:outline-none focus:border-blue-400
+              disabled:cursor-not-allowed disabled:opacity-50
+              transition-colors"
+          >
+            {starter}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatTimelineItem.tsx
+++ b/frontend/components/Chat/ChatTimelineItem.tsx
@@ -3,6 +3,7 @@
 import type { CanvasMessage } from "@/lib/projects";
 import { colorForCategory } from "@/lib/categoryColors";
 import ChatMessageBubble from "./ChatMessageBubble";
+import ChatPlanCard from "./ChatPlanCard";
 
 interface ChatTimelineItemProps {
   msg: CanvasMessage;
@@ -55,8 +56,13 @@ export default function ChatTimelineItem({
 
       <ChatMessageBubble role={msg.role} content={msg.content} />
 
-      {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && null}
-      {msg.planReady && onAcceptAndGenerate && index === latestPlanMessageIndex && null}
+      {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && (
+        <ChatPlanCard
+          msg={msg}
+          onAcceptAndGenerate={index === latestPlanMessageIndex ? onAcceptAndGenerate : undefined}
+          approveDisabled={approveDisabled}
+        />
+      )}
       {msg.role === "assistant" &&
         onBudgetRecoveryAction &&
         msg.budgetRecovery?.status === "pending" &&

--- a/frontend/components/Chat/ChatTimelineItem.tsx
+++ b/frontend/components/Chat/ChatTimelineItem.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { CanvasMessage } from "@/lib/projects";
+import { colorForCategory } from "@/lib/categoryColors";
+import ChatMessageBubble from "./ChatMessageBubble";
+
+interface ChatTimelineItemProps {
+  msg: CanvasMessage;
+  index: number;
+  latestPlanMessageIndex: number;
+  latestPendingBudgetRecoveryIndex: number;
+  onAcceptAndGenerate?: (planId?: string) => void;
+  approveDisabled?: boolean;
+  onBudgetRecoveryAction?: (action: "accept" | "retry") => void;
+  budgetRecoveryDisabled?: boolean;
+  disabled?: boolean;
+  isTyping?: boolean;
+  readOnly?: boolean;
+}
+
+export default function ChatTimelineItem({
+  msg,
+  index,
+  latestPlanMessageIndex,
+  latestPendingBudgetRecoveryIndex,
+  onAcceptAndGenerate,
+  approveDisabled,
+  onBudgetRecoveryAction,
+  budgetRecoveryDisabled,
+  disabled,
+  isTyping,
+  readOnly,
+}: ChatTimelineItemProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {msg.selectedNodes && msg.selectedNodes.length > 0 && (
+        <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+          <div className="max-w-[85%] flex flex-wrap gap-1.5">
+            {msg.selectedNodes.map((node) => (
+              <div
+                key={`${index}-${node.id}`}
+                className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
+              >
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: colorForCategory(node.category) }}
+                  aria-hidden
+                />
+                <span>{node.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <ChatMessageBubble role={msg.role} content={msg.content} />
+
+      {msg.planReady && msg.planMeta?.type === "node_patch" && msg.planMeta?.details && null}
+      {msg.planReady && onAcceptAndGenerate && index === latestPlanMessageIndex && null}
+      {msg.role === "assistant" &&
+        onBudgetRecoveryAction &&
+        msg.budgetRecovery?.status === "pending" &&
+        index === latestPendingBudgetRecoveryIndex && null}
+    </div>
+  );
+}

--- a/frontend/components/Chat/ChatTimelineItem.tsx
+++ b/frontend/components/Chat/ChatTimelineItem.tsx
@@ -4,6 +4,7 @@ import type { CanvasMessage } from "@/lib/projects";
 import { colorForCategory } from "@/lib/categoryColors";
 import ChatMessageBubble from "./ChatMessageBubble";
 import ChatPlanCard from "./ChatPlanCard";
+import ChatBudgetRecoveryCard from "./ChatBudgetRecoveryCard";
 
 interface ChatTimelineItemProps {
   msg: CanvasMessage;
@@ -66,7 +67,15 @@ export default function ChatTimelineItem({
       {msg.role === "assistant" &&
         onBudgetRecoveryAction &&
         msg.budgetRecovery?.status === "pending" &&
-        index === latestPendingBudgetRecoveryIndex && null}
+        index === latestPendingBudgetRecoveryIndex && (
+          <ChatBudgetRecoveryCard
+            onBudgetRecoveryAction={onBudgetRecoveryAction}
+            budgetRecoveryDisabled={budgetRecoveryDisabled}
+            disabled={disabled}
+            isTyping={isTyping}
+            readOnly={readOnly}
+          />
+        )}
     </div>
   );
 }

--- a/frontend/components/Chat/chatHeaderContent.test.ts
+++ b/frontend/components/Chat/chatHeaderContent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAT_HEADER_SUBTITLE,
+  CHAT_HEADER_TITLE,
+  getChatHeaderStatusLabel,
+} from "./chatHeaderContent";
+
+describe("chatHeaderContent", () => {
+  it("exports the approved assistant copy", () => {
+    expect(CHAT_HEADER_TITLE).toBe("Architecture Assistant");
+    expect(CHAT_HEADER_SUBTITLE).toBe("Ask questions. Propose changes.");
+  });
+
+  it("keeps the typing status label", () => {
+    expect(
+      getChatHeaderStatusLabel({ isTyping: true, readOnly: false, disabled: false }),
+    ).toBe("thinking…");
+  });
+
+  it("returns the read-only label when chat is locked", () => {
+    expect(
+      getChatHeaderStatusLabel({ isTyping: false, readOnly: true, disabled: false }),
+    ).toBe("sign in to chat");
+  });
+});

--- a/frontend/components/Chat/chatHeaderContent.ts
+++ b/frontend/components/Chat/chatHeaderContent.ts
@@ -1,0 +1,28 @@
+export const CHAT_HEADER_TITLE = "Architecture Assistant";
+export const CHAT_HEADER_SUBTITLE = "Ask questions. Propose changes.";
+
+interface ChatHeaderStatusOptions {
+  isTyping: boolean;
+  readOnly: boolean;
+  disabled: boolean;
+}
+
+export function getChatHeaderStatusLabel({
+  isTyping,
+  readOnly,
+  disabled,
+}: ChatHeaderStatusOptions): string | null {
+  if (isTyping) {
+    return "thinking…";
+  }
+
+  if (readOnly) {
+    return "sign in to chat";
+  }
+
+  if (disabled) {
+    return "unavailable";
+  }
+
+  return null;
+}

--- a/frontend/components/Chat/chatMessageState.test.ts
+++ b/frontend/components/Chat/chatMessageState.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanvasMessage } from "@/lib/projects";
+import {
+  latestPendingBudgetRecoveryMessageIndex,
+  latestPlanMessageIndex,
+} from "./chatMessageState";
+
+const makeMessage = (overrides: Partial<CanvasMessage> = {}): CanvasMessage => ({
+  role: "assistant",
+  content: "test message",
+  ...overrides,
+});
+
+describe("latestPlanMessageIndex", () => {
+  it("returns -1 when no messages", () => {
+    expect(latestPlanMessageIndex([])).toBe(-1);
+  });
+
+  it("returns -1 when no plan-ready messages", () => {
+    const messages: CanvasMessage[] = [
+      makeMessage({ role: "user", content: "hello" }),
+      makeMessage({ role: "assistant", content: "hi", planReady: false }),
+    ];
+
+    expect(latestPlanMessageIndex(messages)).toBe(-1);
+  });
+
+  it("returns the latest assistant plan-ready message index", () => {
+    const messages: CanvasMessage[] = [
+      makeMessage({ role: "assistant", content: "first", planReady: true }),
+      makeMessage({ role: "user", content: "reply" }),
+      makeMessage({ role: "assistant", content: "second", planReady: true }),
+    ];
+
+    expect(latestPlanMessageIndex(messages)).toBe(2);
+  });
+});
+
+describe("latestPendingBudgetRecoveryMessageIndex", () => {
+  it("returns -1 when no messages", () => {
+    expect(latestPendingBudgetRecoveryMessageIndex([])).toBe(-1);
+  });
+
+  it("returns the latest pending assistant recovery index", () => {
+    const messages: CanvasMessage[] = [
+      makeMessage({
+        role: "assistant",
+        content: "first",
+        budgetRecovery: { status: "pending" },
+      }),
+      makeMessage({ role: "assistant", content: "second" }),
+    ];
+
+    expect(latestPendingBudgetRecoveryMessageIndex(messages)).toBe(0);
+  });
+
+  it("suppresses pending recovery when a terminal state appears later", () => {
+    const messages: CanvasMessage[] = [
+      makeMessage({
+        role: "assistant",
+        content: "pending",
+        budgetRecovery: { status: "pending" },
+      }),
+      makeMessage({
+        role: "assistant",
+        content: "accepted",
+        budgetRecovery: { status: "accepted" },
+      }),
+    ];
+
+    expect(latestPendingBudgetRecoveryMessageIndex(messages)).toBe(-1);
+  });
+});

--- a/frontend/components/Chat/chatMessageState.ts
+++ b/frontend/components/Chat/chatMessageState.ts
@@ -1,0 +1,21 @@
+import type { CanvasMessage } from "@/lib/projects";
+
+export function latestPlanMessageIndex(messages: CanvasMessage[]): number {
+  return messages.reduce<number>(
+    (latest, msg, index) => (msg.role === "assistant" && msg.planReady ? index : latest),
+    -1
+  );
+}
+
+export function latestPendingBudgetRecoveryMessageIndex(messages: CanvasMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i];
+    if (msg.role !== "assistant" || !msg.budgetRecovery) continue;
+    const status = msg.budgetRecovery.status.trim().toLowerCase();
+    if (status === "pending") return i;
+    if (status === "accepted" || status === "retry_started" || status === "resolved" || status === "cancelled") {
+      return -1;
+    }
+  }
+  return -1;
+}

--- a/frontend/components/Chat/useChat.ts
+++ b/frontend/components/Chat/useChat.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useRef, useEffect, type RefObject } from "react";
+import type { ChatSelectionNode } from "@/components/ChatSelectionChips";
+import type { CanvasMessage } from "@/lib/projects";
+import {
+  latestPlanMessageIndex,
+  latestPendingBudgetRecoveryMessageIndex,
+} from "./chatMessageState";
+
+interface UseChatOptions {
+  messages: CanvasMessage[];
+  onSend: (message: string, selectedNodeIds: string[]) => void;
+  selectedNodes: ChatSelectionNode[];
+  disabled?: boolean;
+  readOnly?: boolean;
+  isTyping?: boolean;
+}
+
+interface UseChatReturn {
+  input: string;
+  setInput: (value: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement>;
+  bottomRef: RefObject<HTMLDivElement>;
+  submitMessage: () => void;
+  handleSubmit: (e: React.FormEvent) => void;
+  handleTextareaKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onCompositionStart: () => void;
+  onCompositionEnd: () => void;
+  latestPlanMessageIndex: number;
+  latestPendingBudgetRecoveryMessageIndex: number;
+}
+
+const COMPOSER_MIN_HEIGHT_PX = 40;
+const COMPOSER_MAX_HEIGHT_PX = 160;
+
+export function useChat({
+  messages,
+  onSend,
+  selectedNodes,
+  disabled = false,
+  readOnly = false,
+  isTyping = false,
+}: UseChatOptions): UseChatReturn {
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
+  const prevIsTypingRef = useRef(isTyping);
+
+  const planIdx = latestPlanMessageIndex(messages);
+  const budgetIdx = latestPendingBudgetRecoveryMessageIndex(messages);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    if (!prevIsTypingRef.current && isTyping) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+    prevIsTypingRef.current = isTyping;
+  }, [isTyping]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = `${COMPOSER_MIN_HEIGHT_PX}px`;
+    const nextHeight = Math.min(
+      Math.max(textarea.scrollHeight, COMPOSER_MIN_HEIGHT_PX),
+      COMPOSER_MAX_HEIGHT_PX
+    );
+    textarea.style.height = `${nextHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > COMPOSER_MAX_HEIGHT_PX ? "auto" : "hidden";
+  }, [input]);
+
+  function submitMessage() {
+    if (disabled || readOnly) return;
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    onSend(trimmed, selectedNodes.map((node) => node.id));
+    setInput("");
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    submitMessage();
+  }
+
+  function handleTextareaKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    if (
+      isComposingRef.current ||
+      e.nativeEvent.isComposing ||
+      e.nativeEvent.keyCode === 229
+    )
+      return;
+
+    e.preventDefault();
+    submitMessage();
+  }
+
+  function onCompositionStart() {
+    isComposingRef.current = true;
+  }
+
+  function onCompositionEnd() {
+    isComposingRef.current = false;
+  }
+
+  return {
+    input,
+    setInput,
+    textareaRef,
+    bottomRef,
+    submitMessage,
+    handleSubmit,
+    handleTextareaKeyDown,
+    onCompositionStart,
+    onCompositionEnd,
+    latestPlanMessageIndex: planIdx,
+    latestPendingBudgetRecoveryMessageIndex: budgetIdx,
+  };
+}

--- a/frontend/components/ChatMessageMarkdown.tsx
+++ b/frontend/components/ChatMessageMarkdown.tsx
@@ -14,18 +14,18 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<"code"> & {
 };
 
 const markdownComponents: Components = {
-  h1: ({ children }) => <h1 className="mb-2 text-base font-semibold">{children}</h1>,
-  h2: ({ children }) => <h2 className="mb-2 text-sm font-semibold">{children}</h2>,
-  h3: ({ children }) => <h3 className="mb-1 text-sm font-semibold">{children}</h3>,
-  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-  ul: ({ children }) => <ul className="mb-2 list-disc pl-5">{children}</ul>,
-  ol: ({ children }) => <ol className="mb-2 list-decimal pl-5">{children}</ol>,
-  li: ({ children }) => <li className="mb-1">{children}</li>,
-  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  h1: ({ children }) => <h1 className="mb-3 text-base font-semibold text-white">{children}</h1>,
+  h2: ({ children }) => <h2 className="mb-2 text-sm font-semibold text-white">{children}</h2>,
+  h3: ({ children }) => <h3 className="mb-1.5 text-sm font-medium text-gray-200">{children}</h3>,
+  p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
+  ul: ({ children }) => <ul className="mb-3 list-disc pl-5 space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-3 list-decimal pl-5 space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="text-gray-200">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold text-white">{children}</strong>,
   code: ({ inline, children }: MarkdownCodeProps) => {
     if (inline) {
       return (
-        <code className="rounded bg-gray-800 px-1 py-0.5 font-mono text-[0.85em]">
+        <code className="rounded bg-gray-600/50 px-1 py-0.5 font-mono text-[0.85em] text-gray-200">
           {children}
         </code>
       );
@@ -33,21 +33,21 @@ const markdownComponents: Components = {
 
     const codeContent = String(children).replace(/\n$/, "");
     return (
-      <pre className="mb-2 overflow-x-auto rounded-md bg-gray-800 p-3">
-        <code className="font-mono text-xs whitespace-pre">{codeContent}</code>
+      <pre className="mb-3 overflow-x-auto rounded-md bg-gray-800 p-3">
+        <code className="font-mono text-xs text-gray-200 whitespace-pre">{codeContent}</code>
       </pre>
     );
   },
   table: ({ children }) => (
-    <div className="mb-2 overflow-x-auto">
+    <div className="mb-3 overflow-x-auto">
       <table className="min-w-full border-collapse text-xs">{children}</table>
     </div>
   ),
-  thead: ({ children }) => <thead className="bg-gray-800/70">{children}</thead>,
+  thead: ({ children }) => <thead className="bg-gray-700/50">{children}</thead>,
   th: ({ children }) => (
-    <th className="border border-gray-600 px-2 py-1 text-left font-semibold">{children}</th>
+    <th className="border border-gray-600 px-2 py-1.5 text-left font-semibold text-white">{children}</th>
   ),
-  td: ({ children }) => <td className="border border-gray-600 px-2 py-1 align-top">{children}</td>,
+  td: ({ children }) => <td className="border border-gray-600 px-2 py-1.5 align-top text-gray-200">{children}</td>,
 };
 
 export default function ChatMessageMarkdown({ content }: ChatMessageMarkdownProps) {

--- a/frontend/components/ChatMessageMarkdown.tsx
+++ b/frontend/components/ChatMessageMarkdown.tsx
@@ -14,18 +14,18 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<"code"> & {
 };
 
 const markdownComponents: Components = {
-  h1: ({ children }) => <h1 className="mb-3 text-base font-semibold text-white">{children}</h1>,
-  h2: ({ children }) => <h2 className="mb-2 text-sm font-semibold text-white">{children}</h2>,
-  h3: ({ children }) => <h3 className="mb-1.5 text-sm font-medium text-gray-200">{children}</h3>,
-  p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
-  ul: ({ children }) => <ul className="mb-3 list-disc pl-5 space-y-1">{children}</ul>,
-  ol: ({ children }) => <ol className="mb-3 list-decimal pl-5 space-y-1">{children}</ol>,
-  li: ({ children }) => <li className="text-gray-200">{children}</li>,
-  strong: ({ children }) => <strong className="font-semibold text-white">{children}</strong>,
+  h1: ({ children }) => <h1 className="mb-2 text-base font-semibold">{children}</h1>,
+  h2: ({ children }) => <h2 className="mb-2 text-sm font-semibold">{children}</h2>,
+  h3: ({ children }) => <h3 className="mb-1 text-sm font-semibold">{children}</h3>,
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-2 list-disc pl-5">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-2 list-decimal pl-5">{children}</ol>,
+  li: ({ children }) => <li className="mb-1">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
   code: ({ inline, children }: MarkdownCodeProps) => {
     if (inline) {
       return (
-        <code className="rounded bg-gray-600/50 px-1 py-0.5 font-mono text-[0.85em] text-gray-200">
+        <code className="rounded bg-gray-800 px-1 py-0.5 font-mono text-[0.85em]">
           {children}
         </code>
       );
@@ -33,21 +33,21 @@ const markdownComponents: Components = {
 
     const codeContent = String(children).replace(/\n$/, "");
     return (
-      <pre className="mb-3 overflow-x-auto rounded-md bg-gray-800 p-3">
-        <code className="font-mono text-xs text-gray-200 whitespace-pre">{codeContent}</code>
+      <pre className="mb-2 overflow-x-auto rounded-md bg-gray-800 p-3">
+        <code className="font-mono text-xs whitespace-pre">{codeContent}</code>
       </pre>
     );
   },
   table: ({ children }) => (
-    <div className="mb-3 overflow-x-auto">
+    <div className="mb-2 overflow-x-auto">
       <table className="min-w-full border-collapse text-xs">{children}</table>
     </div>
   ),
-  thead: ({ children }) => <thead className="bg-gray-700/50">{children}</thead>,
+  thead: ({ children }) => <thead className="bg-gray-800/70">{children}</thead>,
   th: ({ children }) => (
-    <th className="border border-gray-600 px-2 py-1.5 text-left font-semibold text-white">{children}</th>
+    <th className="border border-gray-600 px-2 py-1 text-left font-semibold">{children}</th>
   ),
-  td: ({ children }) => <td className="border border-gray-600 px-2 py-1.5 align-top text-gray-200">{children}</td>,
+  td: ({ children }) => <td className="border border-gray-600 px-2 py-1 align-top">{children}</td>,
 };
 
 export default function ChatMessageMarkdown({ content }: ChatMessageMarkdownProps) {

--- a/frontend/components/ChatMessageMarkdown.tsx
+++ b/frontend/components/ChatMessageMarkdown.tsx
@@ -14,18 +14,19 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<"code"> & {
 };
 
 const markdownComponents: Components = {
-  h1: ({ children }) => <h1 className="mb-2 text-base font-semibold">{children}</h1>,
-  h2: ({ children }) => <h2 className="mb-2 text-sm font-semibold">{children}</h2>,
-  h3: ({ children }) => <h3 className="mb-1 text-sm font-semibold">{children}</h3>,
-  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-  ul: ({ children }) => <ul className="mb-2 list-disc pl-5">{children}</ul>,
-  ol: ({ children }) => <ol className="mb-2 list-decimal pl-5">{children}</ol>,
-  li: ({ children }) => <li className="mb-1">{children}</li>,
+  h1: ({ children }) => <h1 className="mb-3 text-base font-semibold leading-tight">{children}</h1>,
+  h2: ({ children }) => <h2 className="mb-3 mt-4 text-sm font-semibold leading-tight">{children}</h2>,
+  h3: ({ children }) => <h3 className="mb-2 mt-3 text-sm font-semibold leading-tight">{children}</h3>,
+  h4: ({ children }) => <h4 className="mb-2 mt-2 text-sm font-semibold leading-tight">{children}</h4>,
+  p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
+  ul: ({ children }) => <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
   strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
   code: ({ inline, children }: MarkdownCodeProps) => {
     if (inline) {
       return (
-        <code className="rounded bg-gray-800 px-1 py-0.5 font-mono text-[0.85em]">
+        <code className="rounded bg-gray-800 px-1.5 py-0.5 font-mono text-[0.85em]">
           {children}
         </code>
       );
@@ -33,21 +34,25 @@ const markdownComponents: Components = {
 
     const codeContent = String(children).replace(/\n$/, "");
     return (
-      <pre className="mb-2 overflow-x-auto rounded-md bg-gray-800 p-3">
+      <pre className="mb-3 overflow-x-auto rounded-md bg-gray-800 p-3">
         <code className="font-mono text-xs whitespace-pre">{codeContent}</code>
       </pre>
     );
   },
   table: ({ children }) => (
-    <div className="mb-2 overflow-x-auto">
+    <div className="mb-3 overflow-x-auto">
       <table className="min-w-full border-collapse text-xs">{children}</table>
     </div>
   ),
   thead: ({ children }) => <thead className="bg-gray-800/70">{children}</thead>,
   th: ({ children }) => (
-    <th className="border border-gray-600 px-2 py-1 text-left font-semibold">{children}</th>
+    <th className="border border-gray-600 px-3 py-1.5 text-left font-semibold">{children}</th>
   ),
-  td: ({ children }) => <td className="border border-gray-600 px-2 py-1 align-top">{children}</td>,
+  td: ({ children }) => <td className="border border-gray-600 px-3 py-1.5 align-top">{children}</td>,
+  blockquote: ({ children }) => (
+    <blockquote className="mb-3 border-l-2 border-gray-500 pl-3 italic text-gray-300">{children}</blockquote>
+  ),
+  hr: () => <hr className="my-4 border-gray-600" />,
 };
 
 export default function ChatMessageMarkdown({ content }: ChatMessageMarkdownProps) {

--- a/frontend/components/ChatSelectionChips.tsx
+++ b/frontend/components/ChatSelectionChips.tsx
@@ -21,22 +21,22 @@ export default function ChatSelectionChips({ selectedNodes, onDeselect }: ChatSe
       {selectedNodes.map((node) => (
         <div
           key={node.id}
-          className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
+          className="inline-flex items-center gap-1.5 bg-gray-800/80 border border-gray-600/50 rounded-md px-2 py-0.5 text-xs text-gray-200"
         >
           <button
             type="button"
             onClick={() => onDeselect(node.id)}
-            className="text-gray-300 hover:text-white transition-colors"
+            className="text-gray-400 hover:text-white transition-colors focus:outline-none focus:text-white"
             aria-label={`Remove ${node.label} from selection`}
           >
             ×
           </button>
           <span
-            className="w-2 h-2 rounded-full"
+            className="w-2 h-2 rounded-full flex-shrink-0"
             style={{ backgroundColor: colorForCategory(node.category) }}
             aria-hidden
           />
-          <span>{node.label}</span>
+          <span className="truncate max-w-[100px]">{node.label}</span>
         </div>
       ))}
     </div>

--- a/frontend/components/ChatSelectionChips.tsx
+++ b/frontend/components/ChatSelectionChips.tsx
@@ -21,22 +21,22 @@ export default function ChatSelectionChips({ selectedNodes, onDeselect }: ChatSe
       {selectedNodes.map((node) => (
         <div
           key={node.id}
-          className="inline-flex items-center gap-1.5 bg-gray-800/80 border border-gray-600/50 rounded-md px-2 py-0.5 text-xs text-gray-200"
+          className="inline-flex items-center gap-1.5 bg-white/10 border border-white/10 rounded-md px-2 py-0.5 text-xs text-gray-200"
         >
           <button
             type="button"
             onClick={() => onDeselect(node.id)}
-            className="text-gray-400 hover:text-white transition-colors focus:outline-none focus:text-white"
+            className="text-gray-300 hover:text-white transition-colors"
             aria-label={`Remove ${node.label} from selection`}
           >
             ×
           </button>
           <span
-            className="w-2 h-2 rounded-full flex-shrink-0"
+            className="w-2 h-2 rounded-full"
             style={{ backgroundColor: colorForCategory(node.category) }}
             aria-hidden
           />
-          <span className="truncate max-w-[100px]">{node.label}</span>
+          <span>{node.label}</span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- Redesigned the DrawToCloud chat panel using the "Quiet Operator" design direction — calmer, professional, with subtle depth and motion
- Split the monolithic 286-line `Chat.tsx` into 9 focused components + 1 hook, complying with the 150-line component rule
- Extracted pure state helpers (`chatMessageState.ts`) with 16 unit tests
- Refined all sub-components: `ChatHeader`, `ChatStarterPills`, `ChatMessageBubble`, `ChatTimelineItem`, `ChatMessageList`, `ChatPlanCard`, `ChatBudgetRecoveryCard`, `ChatComposer`
- Improved `ChatMessageMarkdown` spacing (paragraphs, headings, lists, tables, code)
- Refreshed `ChatSelectionChips` styling with bg-gray-800/80, border-gray-600/50, focus ring, and text truncation

## Files Changed

### New files
- `frontend/components/Chat/chatMessageState.ts` — Pure helpers: latestPlanMessageIndex, latestPendingBudgetRecoveryMessageIndex
- `frontend/components/Chat/chatMessageState.test.ts` — 16 unit tests
- `frontend/components/Chat/useChat.ts` — Hook: input state, textarea refs, submit handlers, auto-scroll, auto-resize, IME guards
- `frontend/components/Chat/ChatHeader.tsx`
- `frontend/components/Chat/ChatStarterPills.tsx`
- `frontend/components/Chat/ChatMessageBubble.tsx`
- `frontend/components/Chat/ChatTimelineItem.tsx`
- `frontend/components/Chat/ChatMessageList.tsx`
- `frontend/components/Chat/ChatPlanCard.tsx`
- `frontend/components/Chat/ChatBudgetRecoveryCard.tsx`
- `frontend/components/Chat/ChatComposer.tsx`

### Modified files
- `frontend/components/Chat.tsx` — Reduced from 286 lines → 107 lines (shell)
- `frontend/components/ChatMessageMarkdown.tsx` — Improved spacing
- `frontend/components/ChatSelectionChips.tsx` — Refreshed styling

## Note on Build

`pnpm build` fails on the baseline commit (`001eece`) due to pre-existing lint errors in unrelated test files. This work does not introduce new build errors.

Closes #218