### PR TITLE
fix: clone templates into a new project on Load

### DIFF
--- a/documents/plans/2025-04-26-fix-template-load-clone.md
+++ b/documents/plans/2025-04-26-fix-template-load-clone.md
@@ -1,0 +1,124 @@
+# Fix: Template 'Load' does not create a new project (Issue #236)
+
+> **For agentic workers:** REQUIRED: Use superpowers:test-driven-development and superpowers:verification-before-completion. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `handleUseTemplate` function so that clicking **Load** on a template creates a new project by cloning the template server-side, then redirects to the newly created project.
+
+**Architecture:** Replace the local-only `fetchTemplateDetail` + `loadTemplateSnapshot` flow in `handleUseTemplate` with a single `cloneTemplate` API call that creates a persisted project on the backend, followed by a client-side redirect to the new project's URL.
+
+**Tech Stack:** Next.js 14 (frontend), Vitest (testing), React hooks
+
+---
+
+## Problem Summary
+
+`handleUseTemplate` in `frontend/app/usePageState.ts` currently:
+1. Calls `fetchTemplateDetail(slug)` (GET `/api/templates/{slug}`)
+2. Calls `pipeline.loadTemplateSnapshot(template)` to hydrate local React Flow state
+3. Does **not** create a new project or redirect
+
+The backend already supports cloning via `POST /api/templates/{slug}/clone`, and the frontend already has a `cloneTemplate()` helper in `frontend/lib/templates.ts`. The fix is to wire them together.
+
+---
+
+## Files to Modify
+
+- `frontend/app/usePageState.ts` — change `handleUseTemplate` implementation
+- `frontend/app/__tests__/usePageState.test.ts` — add test for new cloning behavior
+
+---
+
+## Task 1: Add failing test for `handleUseTemplate` cloning behavior
+
+**Files:**
+- Modify: `frontend/app/__tests__/usePageState.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that asserts:
+- `handleUseTemplate` calls `cloneTemplate` (not `fetchTemplateDetail`)
+- On success, it calls `workspace.openProject` with the returned `share_slug`
+- It does **not** call `pipeline.loadTemplateSnapshot`
+
+```typescript
+it("clones template and redirects to new project when user clicks Load", async () => {
+  // ... test body
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run app/__tests__/usePageState.test.ts`
+Expected: FAIL — `cloneTemplate` is not imported or called
+
+---
+
+## Task 2: Implement the fix in `handleUseTemplate`
+
+**Files:**
+- Modify: `frontend/app/usePageState.ts`
+
+- [ ] **Step 3: Replace `fetchTemplateDetail` with `cloneTemplate`**
+
+Changes in `frontend/app/usePageState.ts`:
+1. Change the import from `fetchTemplateDetail` to `cloneTemplate`
+2. Update `handleUseTemplate` to call `cloneTemplate(slug)`
+3. On success, call `workspace.openProject(response.share_slug)` instead of `pipeline.loadTemplateSnapshot(template)`
+4. Keep the confirmation dialog for non-empty canvas
+5. Keep error handling with `toast.error`
+
+```typescript
+import { cloneTemplate } from "@/lib/templates";
+
+async function handleUseTemplate(slug: string) {
+  if (interactionsLocked) return;
+  if (pipeline.nodes.length > 0) {
+    const shouldReplace = window.confirm(
+      "Discard current design? Loading this template will replace your current canvas."
+    );
+    if (!shouldReplace) return;
+  }
+  try {
+    const response = await cloneTemplate(slug);
+    workspace.openProject(response.share_slug);
+    toast.success("Template cloned successfully");
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : "Failed to clone template");
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run app/__tests__/usePageState.test.ts`
+Expected: PASS
+
+---
+
+## Task 3: Verify no regressions
+
+- [ ] **Step 5: Run all frontend tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit the fix**
+
+```bash
+git add frontend/app/usePageState.ts frontend/app/__tests__/usePageState.test.ts
+git commit -m "fix: template Load now clones project server-side instead of overwriting canvas
+
+Fixes #236
+- Replace fetchTemplateDetail + loadTemplateSnapshot with cloneTemplate
+- Redirect to newly created project after successful clone
+- Update test to assert cloning behavior instead of local snapshot load"
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `handleUseTemplate` calls `cloneTemplate` and redirects on success
+- [ ] `handleUseTemplate` no longer calls `fetchTemplateDetail` or `loadTemplateSnapshot`
+- [ ] Test verifies cloning + redirect behavior
+- [ ] All existing tests still pass

--- a/frontend/app/__tests__/usePageState.test.ts
+++ b/frontend/app/__tests__/usePageState.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+// Mock window.confirm for template load tests
+Object.defineProperty(window, "confirm", {
+  writable: true,
+  value: vi.fn(),
+});
+
 vi.mock("@/lib/useWorkspace", () => ({
   useWorkspace: vi.fn(),
 }));
@@ -31,6 +37,7 @@ vi.mock("@/lib/useSaveProject", () => ({
 
 vi.mock("@/lib/templates", () => ({
   fetchTemplateDetail: vi.fn(),
+  cloneTemplate: vi.fn(),
 }));
 
 vi.mock("@/lib/projects", () => ({}));
@@ -77,5 +84,54 @@ describe("usePageState handleGenerateTerraform", () => {
     expect(openGeneration).toHaveBeenCalledTimes(1);
     expect(openOutput).not.toHaveBeenCalled();
     expect(generateTerraform).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("usePageState handleUseTemplate", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  it("clones template and redirects to new project when user clicks Load", async () => {
+    const openProject = vi.fn();
+    const loadTemplateSnapshot = vi.fn();
+
+    const mockWorkspaceVal = {
+      user: { id: "user-1", email: "test@example.com" },
+      requireAuth: vi.fn().mockReturnValue(true),
+      currentProject: null,
+      isOwner: true,
+      creatingProject: false,
+      rightPanelOpen: false,
+      rightPanelTab: "generation" as const,
+      openProject,
+      closeRightPanel: vi.fn(),
+      pipeline: {
+        nodes: [],
+        terraformProgress: { status: "idle" },
+        terraformFiles: [],
+        isGenerating: false,
+        chatEnabled: true,
+        chatDisabledReason: null,
+        pendingArchitecturePlanId: null,
+        loadTemplateSnapshot,
+      },
+    };
+
+    (await import("@/lib/useWorkspace")).useWorkspace.mockReturnValue(mockWorkspaceVal);
+
+    const { cloneTemplate } = await import("@/lib/templates");
+    (cloneTemplate as ReturnType<typeof vi.fn>).mockResolvedValue({ share_slug: "cloned-proj-123" });
+
+    const { usePageState } = await import("../usePageState");
+    const { handleUseTemplate } = usePageState();
+
+    await handleUseTemplate("my-template");
+
+    expect(cloneTemplate).toHaveBeenCalledTimes(1);
+    expect(cloneTemplate).toHaveBeenCalledWith("my-template");
+    expect(openProject).toHaveBeenCalledTimes(1);
+    expect(openProject).toHaveBeenCalledWith("cloned-proj-123");
+    expect(loadTemplateSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/__tests__/usePageState.test.ts
+++ b/frontend/app/__tests__/usePageState.test.ts
@@ -6,6 +6,14 @@ Object.defineProperty(window, "confirm", {
   value: vi.fn(),
 });
 
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
 vi.mock("@/lib/useWorkspace", () => ({
   useWorkspace: vi.fn(),
 }));
@@ -90,6 +98,7 @@ describe("usePageState handleGenerateTerraform", () => {
 describe("usePageState handleUseTemplate", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.mocked(window.confirm).mockReturnValue(true);
   });
 
   it("clones template and redirects to new project when user clicks Load", async () => {
@@ -133,5 +142,89 @@ describe("usePageState handleUseTemplate", () => {
     expect(openProject).toHaveBeenCalledTimes(1);
     expect(openProject).toHaveBeenCalledWith("cloned-proj-123");
     expect(loadTemplateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication before cloning a template", async () => {
+    const requireAuth = vi.fn().mockReturnValue(false);
+    const openProject = vi.fn();
+
+    const mockWorkspaceVal = {
+      user: null,
+      requireAuth,
+      currentProject: null,
+      isOwner: false,
+      creatingProject: false,
+      rightPanelOpen: false,
+      rightPanelTab: "generation" as const,
+      openProject,
+      closeRightPanel: vi.fn(),
+      pipeline: {
+        nodes: [],
+        terraformProgress: { status: "idle" },
+        terraformFiles: [],
+        isGenerating: false,
+        chatEnabled: true,
+        chatDisabledReason: null,
+        pendingArchitecturePlanId: null,
+        loadTemplateSnapshot: vi.fn(),
+      },
+    };
+
+    (await import("@/lib/useWorkspace")).useWorkspace.mockReturnValue(mockWorkspaceVal);
+
+    const { cloneTemplate } = await import("@/lib/templates");
+    const cloneTemplateMock = vi.mocked(cloneTemplate);
+
+    const { usePageState } = await import("../usePageState");
+    const { handleUseTemplate } = usePageState();
+
+    await handleUseTemplate("my-template");
+
+    expect(requireAuth).toHaveBeenCalledTimes(1);
+    expect(cloneTemplateMock).not.toHaveBeenCalled();
+    expect(openProject).not.toHaveBeenCalled();
+  });
+
+  it("does not clone when the user cancels replacing their current design", async () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+    const openProject = vi.fn();
+
+    const mockWorkspaceVal = {
+      user: { id: "user-1", email: "test@example.com" },
+      requireAuth: vi.fn().mockReturnValue(true),
+      currentProject: null,
+      isOwner: true,
+      creatingProject: false,
+      rightPanelOpen: false,
+      rightPanelTab: "generation" as const,
+      openProject,
+      closeRightPanel: vi.fn(),
+      pipeline: {
+        nodes: [{ id: "vpc" }],
+        terraformProgress: { status: "idle" },
+        terraformFiles: [],
+        isGenerating: false,
+        chatEnabled: true,
+        chatDisabledReason: null,
+        pendingArchitecturePlanId: null,
+        loadTemplateSnapshot: vi.fn(),
+      },
+    };
+
+    (await import("@/lib/useWorkspace")).useWorkspace.mockReturnValue(mockWorkspaceVal);
+
+    const { cloneTemplate } = await import("@/lib/templates");
+    const cloneTemplateMock = vi.mocked(cloneTemplate);
+
+    const { usePageState } = await import("../usePageState");
+    const { handleUseTemplate } = usePageState();
+
+    await handleUseTemplate("my-template");
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      "Leave current design and open a new project cloned from this template?"
+    );
+    expect(cloneTemplateMock).not.toHaveBeenCalled();
+    expect(openProject).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/usePageState.ts
+++ b/frontend/app/usePageState.ts
@@ -7,7 +7,7 @@ import { canApplyManualLayout } from "@/lib/manualLayoutPolicy";
 import { getArchitectStatusText, isInteractionLocked } from "@/lib/generationUiState";
 import { useProjectDelete } from "@/lib/projectActions";
 import type { QuestionnaireAnswers } from "@/lib/projects";
-import { fetchTemplateDetail } from "@/lib/templates";
+import { cloneTemplate } from "@/lib/templates";
 import { useSaveProject } from "@/lib/useSaveProject";
 import { useWorkspace } from "@/lib/useWorkspace";
 
@@ -117,11 +117,11 @@ export function usePageState() {
       if (!shouldReplace) return;
     }
     try {
-      const template = await fetchTemplateDetail(slug);
-      pipeline.loadTemplateSnapshot(template);
-      toast.success(`Loaded template: ${template.title}`);
+      const response = await cloneTemplate(slug);
+      workspace.openProject(response.share_slug);
+      toast.success("Template cloned successfully");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to load template");
+      toast.error(error instanceof Error ? error.message : "Failed to clone template");
     }
   }
 

--- a/frontend/app/usePageState.ts
+++ b/frontend/app/usePageState.ts
@@ -110,9 +110,10 @@ export function usePageState() {
 
   async function handleUseTemplate(slug: string) {
     if (interactionsLocked) return;
+    if (!workspace.requireAuth()) return;
     if (pipeline.nodes.length > 0) {
       const shouldReplace = window.confirm(
-        "Discard current design? Loading this template will replace your current canvas."
+        "Leave current design and open a new project cloned from this template?"
       );
       if (!shouldReplace) return;
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@types/sanitize-html": "^2.16.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.35",
+    "jsdom": "^29.0.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-config-next:
         specifier: 14.2.35
         version: 14.2.35(eslint@8.57.1)(typescript@5.9.3)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       postcss:
         specifier: ^8
         version: 8.5.8
@@ -3263,7 +3266,6 @@ snapshots:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -3272,13 +3274,10 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1':
-    optional: true
+  '@asamuzakjp/generational-cache@1.0.1': {}
 
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3293,16 +3292,13 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-    optional: true
 
-  '@csstools/color-helpers@6.0.2':
-    optional: true
+  '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -3310,20 +3306,16 @@ snapshots:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
-    optional: true
 
-  '@csstools/css-tokenizer@4.0.0':
-    optional: true
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -3364,8 +3356,7 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@exodus/bytes@1.15.0':
-    optional: true
+  '@exodus/bytes@1.15.0': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -4372,7 +4363,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-    optional: true
 
   binary-extensions@2.3.0: {}
 
@@ -4479,7 +4469,6 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-    optional: true
 
   cssesc@3.0.0: {}
 
@@ -4534,7 +4523,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4562,8 +4550,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4643,8 +4630,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  entities@8.0.0:
-    optional: true
+  entities@8.0.0: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -5173,7 +5159,6 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   html-url-attributes@3.0.1: {}
 
@@ -5310,8 +5295,7 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5404,7 +5388,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   json-buffer@3.0.1: {}
 
@@ -5507,8 +5490,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.3.5:
-    optional: true
+  lru-cache@11.3.5: {}
 
   lucide-react@0.577.0(react@18.3.1):
     dependencies:
@@ -5677,8 +5659,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.27.1:
-    optional: true
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -6042,7 +6023,6 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
-    optional: true
 
   path-exists@4.0.0: {}
 
@@ -6279,8 +6259,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -6363,7 +6342,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.23.2:
     dependencies:
@@ -6574,8 +6552,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.19):
     dependencies:
@@ -6630,13 +6607,11 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.28:
-    optional: true
+  tldts-core@7.0.28: {}
 
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
-    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6645,12 +6620,10 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
-    optional: true
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   trim-lines@3.0.1: {}
 
@@ -6721,8 +6694,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0:
-    optional: true
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6860,13 +6832,10 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
-  webidl-conversions@8.0.1:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
-  whatwg-mimetype@5.0.0:
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
     dependencies:
@@ -6875,7 +6844,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6945,11 +6913,9 @@ snapshots:
 
   ws@8.19.0: {}
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- switch template Load from local snapshot hydration to the authenticated template clone endpoint and redirect to the new project
- preserve the existing login flow before cloning and update the replace confirmation copy to match the new behavior
- add coverage for clone success, auth gating, and cancel behavior, and add `jsdom` so the Vitest jsdom environment runs locally

## Test Plan
- [x] `cd frontend && pnpm test app/__tests__/usePageState.test.ts`
- [x] `cd frontend && pnpm test`