### PR TITLE
Improve generation rate-limit observability in frontend

### DIFF
--- a/backend/generation_service.py
+++ b/backend/generation_service.py
@@ -18,6 +18,7 @@ from agents.description import run_description_agent
 from agents.log_helper import emit_log
 from agents.requirements import generate_requirements
 from admin import is_admin_email
+from llm_client import LlmProviderRateLimitError
 from llm_keys import LlmKeyDecryptError, get_user_llm_key
 from project_store import append_chat_message, create_project_for_generation, derive_project_title, get_project_for_user, update_project_fields
 from quota import check_and_reserve_quota
@@ -2009,16 +2010,15 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
             project_id, runtime.trace_id, str(error),
             exc_info=not isinstance(error, BaseExceptionGroup),
         )
-        if runtime._generation_observability:
-            for agent in runtime._generation_observability:
-                if agent.get("status") == "running":
-                    await runtime.update_generation_agent(
-                        agent["agent"], "failed", error=str(error),
-                    )
-                    break
         error_code = "pipeline_failed"
+        user_message = str(error)
+        retryable = False
         budget_recovery_metadata: dict[str, Any] | None = None
-        if isinstance(error, BudgetCapUnmetError):
+        if isinstance(error, LlmProviderRateLimitError):
+            error_code = "llm_rate_limited"
+            user_message = str(error)
+            retryable = True
+        elif isinstance(error, BudgetCapUnmetError):
             error_code = error.code
             overage = round(max(error.estimated_total - error.budget_cap, 0.0), 2)
             budget_recovery_metadata = {
@@ -2047,6 +2047,17 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
                     edges=restored_edges,
                     cost_estimate=restored_cost if isinstance(restored_cost, dict) else None,
                 )
+        if runtime._generation_observability:
+            for agent in runtime._generation_observability:
+                if agent.get("status") == "running":
+                    failed_summary = user_message
+                    if isinstance(error, LlmProviderRateLimitError):
+                        failed_summary = "AI provider temporarily rate-limited"
+                    agent["summary"] = failed_summary
+                    await runtime.update_generation_agent(
+                        agent["agent"], "failed", error=user_message,
+                    )
+                    break
         await runtime.persist_partial_state()
         if isinstance(error, BudgetCapUnmetError) and budget_recovery_metadata is not None:
             try:
@@ -2070,15 +2081,17 @@ async def _run_generation(runtime: GenerationRuntime, answers: Any) -> None:
                     project_id,
                     runtime.trace_id,
                 )
-        await runtime.set_generation_state(status="failed", stage="failed", error=str(error), completed=True)
+        await runtime.set_generation_state(status="failed", stage="failed", error=user_message, completed=True)
         await runtime.emit_pipeline_event(
             "pipeline",
             "failed",
             "error",
             "Generation failed",
-            {"error": str(error), "code": error_code},
+            {"error": user_message, "code": error_code},
         )
-        error_payload: dict[str, Any] = {"type": "error", "error": error_code, "message": str(error)}
+        error_payload: dict[str, Any] = {"type": "error", "error": error_code, "message": user_message}
+        if retryable:
+            error_payload["retryable"] = True
         if isinstance(error, BudgetCapUnmetError):
             error_payload["budget_cap"] = error.budget_cap
             error_payload["estimated_total"] = error.estimated_total

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -10,6 +10,13 @@ from dotenv import load_dotenv
 logger = logging.getLogger(__name__)
 
 
+class LlmProviderRateLimitError(Exception):
+    """Raised when the upstream LLM provider returns a 429/rate-limit error."""
+
+    def __init__(self, message: str = "The AI provider is temporarily rate-limited. Retry in a moment or add your own key.") -> None:
+        super().__init__(message)
+
+
 def _load_local_env_files() -> None:
     """Load .env from common backend launch locations."""
     if os.environ.get("PYTHON_DOTENV_DISABLED"):
@@ -111,14 +118,24 @@ async def async_stream_text(
         import anthropic
 
         client = anthropic.AsyncAnthropic(api_key=api_key, timeout=HTTP_CLIENT_TIMEOUT)
-        async with client.messages.stream(
-            model=model,
-            max_tokens=max_tokens,
-            system=system,
-            messages=messages,
-        ) as stream:
-            async for text in stream.text_stream:
-                yield text
+        try:
+            async with client.messages.stream(
+                model=model,
+                max_tokens=max_tokens,
+                system=system,
+                messages=messages,
+            ) as stream:
+                async for text in stream.text_stream:
+                    yield text
+        except anthropic.RateLimitError as exc:
+            logger.warning(
+                "LLM rate limit provider=%s agent=%s trace_id=%s error=%s",
+                provider,
+                agent,
+                trace_id,
+                exc,
+            )
+            raise LlmProviderRateLimitError() from exc
         logger.info("LLM stream completed provider=%s agent=%s trace_id=%s", provider, agent, trace_id)
     else:
         import openai as oai
@@ -139,7 +156,17 @@ async def async_stream_text(
         else:
             client = oai.AsyncOpenAI(api_key=api_key, timeout=HTTP_CLIENT_TIMEOUT)
 
-        stream = await client.chat.completions.create(**kwargs)
+        try:
+            stream = await client.chat.completions.create(**kwargs)
+        except oai.RateLimitError as exc:
+            logger.warning(
+                "LLM rate limit provider=%s agent=%s trace_id=%s error=%s",
+                provider,
+                agent,
+                trace_id,
+                exc,
+            )
+            raise LlmProviderRateLimitError() from exc
         last_content_at = time.monotonic()
         warned_30 = False
         warned_45 = False

--- a/backend/tests/test_generation_service.py
+++ b/backend/tests/test_generation_service.py
@@ -895,6 +895,37 @@ async def test_run_generation_retries_requirements_once_after_timeout():
 
 
 @pytest.mark.asyncio
+async def test_run_generation_classifies_rate_limit_as_llm_rate_limited():
+    """A provider 429 during requirements generation emits a structured rate-limit error."""
+    from llm_client import LlmProviderRateLimitError
+
+    requirements_mock = AsyncMock(side_effect=LlmProviderRateLimitError())
+
+    runtime = _FakeRuntime()
+    runtime.init_generation_observability()
+
+    with patch("generation_service.generate_requirements", new=requirements_mock):
+        with patch("generation_service.stream_architecture", new=AsyncMock(return_value=None)):
+            with patch("generation_service.run_cost_analyst", new=AsyncMock(return_value=None)):
+                with patch("generation_service.emit_log", new=AsyncMock(return_value=None)):
+                    await generation_service._run_generation(runtime, {"app_name": "Demo"})
+
+    assert not any(payload.get("type") == "done" for payload in runtime.sent_payloads)
+    error_payload = next(payload for payload in runtime.sent_payloads if payload.get("type") == "error")
+    assert error_payload["error"] == "llm_rate_limited"
+    assert error_payload.get("retryable") is True
+    assert "rate-limited" in error_payload["message"].lower() or "retry" in error_payload["message"].lower()
+
+    requirements_agent = next(
+        (a for a in runtime._generation_observability or [] if a["agent"] == "requirements"), None
+    )
+    assert requirements_agent is not None
+    assert requirements_agent["status"] == "failed"
+    assert requirements_agent["error"] is not None
+    assert "rate-limited" in requirements_agent["summary"].lower() or "provider" in requirements_agent["summary"].lower()
+
+
+@pytest.mark.asyncio
 async def test_run_generation_retries_requirements_once_after_parse_failure():
     requirements_mock = AsyncMock(
         side_effect=[ValueError("Requirements agent returned invalid JSON: top-level JSON must be an object"), {"app_name": "Demo"}]

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -261,3 +261,105 @@ def test_async_complete_logs_progressive_stall_warnings_with_context():
                         assert any("45" in message for message in warning_messages)
 
     asyncio.run(run())
+
+
+def test_async_stream_text_classifies_openai_rate_limit_error():
+    """OpenAI 429 during streaming is classified as LlmProviderRateLimitError."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import pytest
+
+    mock_client = MagicMock()
+    rate_limit_exc = pytest.raises
+
+    class FakeRateLimitError(Exception):
+        pass
+
+    fake_rate_limit = FakeRateLimitError("rate limited")
+
+    async def run():
+        with patch("llm_client.resolve_creds", return_value=("openai", "gpt-4o", "sk-test")):
+            with patch("openai.AsyncOpenAI", return_value=mock_client):
+                import openai as oai
+
+                mock_client.chat.completions.create = AsyncMock(side_effect=oai.RateLimitError("rate limited", response=MagicMock(), body=None))
+                from llm_client import async_stream_text, LlmProviderRateLimitError
+
+                with pytest.raises(LlmProviderRateLimitError):
+                    async for _ in async_stream_text(
+                        messages=[{"role": "user", "content": "hello"}],
+                        system="test",
+                    ):
+                        pass
+
+    asyncio.run(run())
+
+
+def test_async_stream_text_classifies_openrouter_rate_limit_error():
+    """OpenRouter 429 during streaming is classified as LlmProviderRateLimitError."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import pytest
+
+    mock_client = MagicMock()
+
+    async def run():
+        with patch("llm_client.resolve_creds", return_value=("openrouter", "model-x", "sk-test")):
+            with patch("openai.AsyncOpenAI", return_value=mock_client):
+                import openai as oai
+
+                mock_client.chat.completions.create = AsyncMock(side_effect=oai.RateLimitError("rate limited", response=MagicMock(), body=None))
+                from llm_client import async_stream_text, LlmProviderRateLimitError
+
+                with pytest.raises(LlmProviderRateLimitError):
+                    async for _ in async_stream_text(
+                        messages=[{"role": "user", "content": "hello"}],
+                        system="test",
+                    ):
+                        pass
+
+    asyncio.run(run())
+
+
+def test_async_stream_text_classifies_anthropic_rate_limit_error():
+    """Anthropic 429 during streaming is classified as LlmProviderRateLimitError."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import pytest
+
+    mock_stream_ctx = AsyncMock()
+    mock_stream_ctx.__aenter__ = AsyncMock(side_effect=Exception("rate limited"))
+    mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_messages = MagicMock()
+    mock_messages.stream = MagicMock(return_value=mock_stream_ctx)
+
+    mock_client = MagicMock()
+    mock_client.messages = mock_messages
+
+    async def run():
+        with patch("llm_client.resolve_creds", return_value=("anthropic", "claude-test", "sk-test")):
+            with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+                import anthropic
+
+                mock_stream_ctx.__aenter__ = AsyncMock(side_effect=anthropic.RateLimitError("rate limited", response=MagicMock(), body=None))
+                from llm_client import async_stream_text, LlmProviderRateLimitError
+
+                with pytest.raises(LlmProviderRateLimitError):
+                    async for _ in async_stream_text(
+                        messages=[{"role": "user", "content": "hello"}],
+                        system="test",
+                    ):
+                        pass
+
+    asyncio.run(run())
+
+
+def test_llm_provider_rate_limit_error_message_is_user_friendly():
+    from llm_client import LlmProviderRateLimitError
+
+    exc = LlmProviderRateLimitError()
+    assert "rate-limited" in str(exc).lower() or "busy" in str(exc).lower() or "retry" in str(exc).lower()

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -197,6 +197,12 @@ Cost Analyst: `started` | `choosing_region` | `inventorying_services` | `pricing
 **Failure propagation:**
 - If an agent fails, downstream agents transition to `blocked`
 - When an upstream completes, downstream agents transition from `blocked` to `queued`
+- When a failure occurs, the running agent's `summary` is updated with a user-facing failure explanation and its `error` field is populated
+
+**Error codes:**
+- `pipeline_failed` — Generic generation failure
+- `budget_cap_unmet` — Estimated cost exceeds the hard budget cap; includes `budget_cap`, `estimated_total`, and `overage` in the error payload
+- `llm_rate_limited` — Upstream AI provider returned a 429/rate-limit; includes `retryable: true` in the error payload
 
 **Lifecycle (initial_generation mode):**
 1. Requirements starts as `queued`, then `running`, then `completed`

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -171,7 +171,7 @@ During initial architecture generation, the right panel auto-opens into a dedica
 | `cost_estimate` | `{ region, monthly_total: float, items: [...], project_id, trace_id }` | Cost breakdown per node with estimated/fixed monthly pricing |
 | `arch_description` | `{ sections: {...}, project_id, trace_id }` | Plain-English architecture description |
 | `setup_pdf_status` | `{ setup_pdf_status, setup_pdf_progress, setup_pdf_error?, setup_pdf_generated_at?, project_id }` | Setup PDF generation progress + terminal state |
-| `error` | `{ error: "unauthenticated"\|"invalid_json"\|..., message }` | Error event |
+| `error` | `{ error: "unauthenticated"\|"invalid_json"\|"llm_rate_limited"\|..., message, retryable? }` | Error event; `llm_rate_limited` indicates a temporary upstream provider rate limit and includes `retryable: true` |
 | `done` | `{ project_id, trace_id }` | Signals end of generation event stream |
 
 **Connection behavior:**

--- a/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
+++ b/frontend/components/GenerationObservabilityPanel/AgentStepCard.tsx
@@ -127,6 +127,10 @@ export default function AgentStepCard({ agent, latestLog }: Props) {
           {agent.summary}
         </p>
 
+        {agent.status === "failed" && agent.error && (
+          <p className="text-[11px] text-red-400 mt-1">{agent.error}</p>
+        )}
+
         {latestLog && agent.status === "running" && (
           <p className="text-[11px] text-gray-500 mt-1">{latestLog}</p>
         )}

--- a/frontend/lib/__tests__/canvasPipelineUtils.test.ts
+++ b/frontend/lib/__tests__/canvasPipelineUtils.test.ts
@@ -103,6 +103,16 @@ describe("inferPipelineErrorCode", () => {
     expect(result).toBe("budget_cap_unmet");
   });
 
+  it("detects llm_rate_limited from error field", () => {
+    const result = inferPipelineErrorCode({ error: "llm_rate_limited" });
+    expect(result).toBe("llm_rate_limited");
+  });
+
+  it("detects llm_rate_limited from message text", () => {
+    expect(inferPipelineErrorCode({}, "The AI provider is temporarily rate-limited")).toBe("llm_rate_limited");
+    expect(inferPipelineErrorCode({}, "rate limited upstream")).toBe("llm_rate_limited");
+  });
+
   it("returns null when no error code is found", () => {
     expect(inferPipelineErrorCode({})).toBeNull();
     expect(inferPipelineErrorCode({ error: "" })).toBeNull();

--- a/frontend/lib/__tests__/generationUiState.test.ts
+++ b/frontend/lib/__tests__/generationUiState.test.ts
@@ -79,6 +79,17 @@ describe("generation UI state", () => {
     ).toBe("Over budget. Use Retry or Accept in chat");
   });
 
+  it("shows rate-limit guidance for provider throttling failures", () => {
+    expect(
+      getArchitectStatusText({
+        isGenerating: false,
+        creatingProject: false,
+        pipelineStatus: "Error: The AI provider is temporarily rate-limited",
+        pipelineErrorCode: "llm_rate_limited",
+      } satisfies GenerationUiInput)
+    ).toBe("AI provider is busy. Retry in a moment");
+  });
+
   it("keeps generation status priority over generic pipeline error", () => {
     expect(
       getArchitectStatusText({

--- a/frontend/lib/__tests__/pipelineWsPayloads.test.ts
+++ b/frontend/lib/__tests__/pipelineWsPayloads.test.ts
@@ -37,4 +37,11 @@ describe("pipelineWsPayloads", () => {
     ).toBe("Cannot generate Terraform: no nodes on canvas. Design your architecture first.");
     expect(pipelineErrorToastMessage("chat_failed", "Something failed")).toBeNull();
   });
+
+  it("returns toast copy for llm_rate_limited errors", () => {
+    const result = pipelineErrorToastMessage("llm_rate_limited", "The AI provider is temporarily rate-limited");
+    expect(result).not.toBeNull();
+    expect(result!.toLowerCase()).toContain("busy");
+    expect(result!.toLowerCase()).toContain("retry");
+  });
 });

--- a/frontend/lib/canvasPipelineUtils.ts
+++ b/frontend/lib/canvasPipelineUtils.ts
@@ -46,6 +46,9 @@ export function inferPipelineErrorCode(
   if (normalizedMessage.includes("budget hard cap unmet")) {
     return "budget_cap_unmet";
   }
+  if (normalizedMessage.includes("rate-limited") || normalizedMessage.includes("rate limited")) {
+    return "llm_rate_limited";
+  }
   return null;
 }
 

--- a/frontend/lib/generationUiState.ts
+++ b/frontend/lib/generationUiState.ts
@@ -18,6 +18,9 @@ export function getArchitectStatusText(input: GenerationUiInput): string | null 
   if (input.pipelineErrorCode === "budget_cap_unmet") {
     return "Over budget. Use Retry or Accept in chat";
   }
+  if (input.pipelineErrorCode === "llm_rate_limited") {
+    return "AI provider is busy. Retry in a moment";
+  }
   if (typeof input.pipelineStatus === "string" && input.pipelineStatus.trim().toLowerCase().startsWith("error:")) {
     return "Generation failed. Try again later";
   }

--- a/frontend/lib/pipelineWsPayloads.ts
+++ b/frontend/lib/pipelineWsPayloads.ts
@@ -40,5 +40,8 @@ export function pipelineErrorToastMessage(errorCode: unknown, message: string): 
   if (errorCode === "no_diagram_nodes") {
     return message;
   }
+  if (errorCode === "llm_rate_limited") {
+    return "AI provider is temporarily busy. Retry in a moment or add your own key.";
+  }
   return null;
 }


### PR DESCRIPTION
## Summary

Closes #240

When generation fails because the upstream AI provider is temporarily rate-limited, the frontend now gives the user clear context about what happened and what to do next.

## Changes

### Backend
- **llm_client.py**: Added `LlmProviderRateLimitError` exception class. Catches `RateLimitError` from OpenAI/OpenRouter and Anthropic SDKs and converts them into a product-level error.
- **generation_service.py**: 
  - Detects `LlmProviderRateLimitError` in the generation failure path
  - Emits websocket error with code `llm_rate_limited` and `retryable: true`
  - Updates the failed agent's summary with user-friendly text: "AI provider temporarily rate-limited"
  - Persists the user-friendly message in `generation_error`

### Frontend
- **canvasPipelineUtils.ts**: `inferPipelineErrorCode` now recognizes `llm_rate_limited` from both the explicit error field and from message text patterns.
- **generationUiState.ts**: Added rate-limit specific status text: "AI provider is busy. Retry in a moment"
- **pipelineWsPayloads.ts**: Added toast message for rate-limit errors with actionable guidance.
- **AgentStepCard.tsx**: Failed agent rows now render the `agent.error` text in red below the summary.

### Tests
- Added backend tests for all three provider paths (OpenAI, OpenRouter, Anthropic) classifying 429s as `LlmProviderRateLimitError`
- Added backend generation test proving rate-limit failures emit structured error payloads
- Added frontend tests for error code inference, UI state text, and toast messages

### Docs
- Updated `platform-docs.md` to document the `llm_rate_limited` error code and `retryable` flag
- Updated `data-reference.md` with error codes section and failure propagation behavior

## Test Results

- Backend: 566 passed (was 561)
- Frontend: 428 passed (was 424)

## Acceptance Criteria

- [x] A provider 429 during generation is surfaced to the client as a stable rate-limit error code, not a generic pipeline failure.
- [x] The failed Requirements row explains that the AI provider is temporarily rate-limited or busy using product-level copy.
- [x] The frontend shows actionable guidance to retry shortly or add a personal key.
- [x] Reconnect and snapshot hydration preserve enough structured failure context for the UI to keep showing the rate-limit explanation.
- [x] Provider and model identifiers remain out of user-facing copy.
- [x] All new tests pass.
- [x] Existing tests still pass.