### PR TITLE
Fix dropped first chat message after template clone websocket race

### DIFF
--- a/frontend/lib/__tests__/canvasActions.test.ts
+++ b/frontend/lib/__tests__/canvasActions.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import {
   useChatActions,
   useChatSendActions,
@@ -9,12 +9,26 @@ import {
   useGenerationActions,
   useTemplateEstimateAndEditActions,
 } from "@/lib/canvasActions";
+import wsClient from "@/lib/websocket";
 
 vi.mock("@/lib/websocket", () => ({
   default: {
     send: vi.fn().mockReturnValue(true),
+    sendWhenOpen: vi.fn().mockResolvedValue(true),
     reconnect: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/supabase/browser", () => ({
+  getSupabaseBrowserClient: vi.fn(() => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: "mock-token" } } }),
+    },
+  })),
+}));
+
+vi.mock("@/lib/chatProjectContext", () => ({
+  ensureChatProjectContext: vi.fn().mockResolvedValue({ projectId: "proj-123" }),
 }));
 
 describe("useChatActions", () => {
@@ -127,6 +141,10 @@ describe("useGenerationActions", () => {
 });
 
 describe("useChatSendActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("returns chat send actions", () => {
     const { result } = renderHook(() =>
       useChatSendActions({
@@ -154,6 +172,95 @@ describe("useChatSendActions", () => {
     );
     expect(result.current.handleSend).toBeInstanceOf(Function);
     expect(result.current.handleBudgetRecoveryAction).toBeInstanceOf(Function);
+  });
+
+  it("uses sendWhenOpen for chat messages so they are not dropped during reconnect", async () => {
+    const failChatRequest = vi.fn();
+    const armChatResponseTimeout = vi.fn();
+    const setMessages = vi.fn();
+    const messagesRef = { current: [] as any[] };
+
+    vi.mocked(wsClient.sendWhenOpen).mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() =>
+      useChatSendActions({
+        canvasSession: null,
+        chatEnabled: true,
+        canvasHasArchitecture: true,
+        messages: [],
+        diagram: { selectedNodeIds: [], canonicalNodes: [], edges: [] } as any,
+        onProjectReady: vi.fn(),
+        clearPendingTemplateEstimateRequest: vi.fn(),
+        failChatRequest,
+        armChatResponseTimeout,
+        chatProjectBootstrapRef: { current: { context: null, pending: null } },
+        setMessages,
+        messagesRef,
+        setIsChatStreaming: vi.fn(),
+        setStreamingAssistantReply: vi.fn(),
+        streamingReplyRef: { current: "" },
+        setPipelineStatus: vi.fn(),
+        setLastEventAt: vi.fn(),
+        setPendingChatPlanId: vi.fn(),
+        setIsGenerating: vi.fn(),
+        setPipelineErrorCode: vi.fn(),
+      })
+    );
+
+    act(() => {
+      result.current.handleSend("hello", []);
+    });
+
+    await waitFor(() => {
+      expect(wsClient.sendWhenOpen).toHaveBeenCalled();
+    });
+
+    expect(failChatRequest).not.toHaveBeenCalled();
+    expect(armChatResponseTimeout).toHaveBeenCalled();
+  });
+
+  it("fails chat request when sendWhenOpen rejects", async () => {
+    const failChatRequest = vi.fn();
+    const armChatResponseTimeout = vi.fn();
+    const setMessages = vi.fn();
+    const messagesRef = { current: [] as any[] };
+
+    vi.mocked(wsClient.sendWhenOpen).mockRejectedValueOnce(new Error("Connection timeout"));
+
+    const { result } = renderHook(() =>
+      useChatSendActions({
+        canvasSession: null,
+        chatEnabled: true,
+        canvasHasArchitecture: true,
+        messages: [],
+        diagram: { selectedNodeIds: [], canonicalNodes: [], edges: [] } as any,
+        onProjectReady: vi.fn(),
+        clearPendingTemplateEstimateRequest: vi.fn(),
+        failChatRequest,
+        armChatResponseTimeout,
+        chatProjectBootstrapRef: { current: { context: null, pending: null } },
+        setMessages,
+        messagesRef,
+        setIsChatStreaming: vi.fn(),
+        setStreamingAssistantReply: vi.fn(),
+        streamingReplyRef: { current: "" },
+        setPipelineStatus: vi.fn(),
+        setLastEventAt: vi.fn(),
+        setPendingChatPlanId: vi.fn(),
+        setIsGenerating: vi.fn(),
+        setPipelineErrorCode: vi.fn(),
+      })
+    );
+
+    act(() => {
+      result.current.handleSend("hello", []);
+    });
+
+    await waitFor(() => {
+      expect(failChatRequest).toHaveBeenCalledWith("Connection timeout");
+    });
+
+    expect(armChatResponseTimeout).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/lib/__tests__/canvasPipelineHooks.test.ts
+++ b/frontend/lib/__tests__/canvasPipelineHooks.test.ts
@@ -61,6 +61,7 @@ describe("useCanvasPipelineDerived", () => {
           manualTerraformRunState: "idle",
           messages: [],
           streamingAssistantReply: "",
+          wsState: "open",
         } as any,
         diagram: { nodes: [], selectedNodeIds: [], canonicalNodes: [] } as any,
         canvasSession: null,
@@ -68,5 +69,26 @@ describe("useCanvasPipelineDerived", () => {
     );
     expect(result.current.activeProjectId).toBeNull();
     expect(result.current.chatEnabled).toBe(true);
+  });
+
+  it("disables chat when websocket is not open", () => {
+    const { result } = renderHook(() =>
+      useCanvasPipelineDerived({
+        readOnly: false,
+        pipeline: {
+          currentStage: "completed",
+          isGenerating: false,
+          isChatStreaming: false,
+          manualTerraformRunState: "idle",
+          messages: [],
+          streamingAssistantReply: "",
+          wsState: "connecting",
+        } as any,
+        diagram: { nodes: [{ id: "n1" }], selectedNodeIds: [], canonicalNodes: [] } as any,
+        canvasSession: { mode: "existing", project: { id: "proj-1" } } as any,
+      })
+    );
+    expect(result.current.chatEnabled).toBe(false);
+    expect(result.current.chatDisabledReason).toBe("Reconnecting to live session...");
   });
 });

--- a/frontend/lib/__tests__/templateChatRegression.test.ts
+++ b/frontend/lib/__tests__/templateChatRegression.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCanvasPipelineDerived } from "@/lib/useCanvasPipelineDerived";
+
+describe("template-chat regression", () => {
+  it("disables chat immediately after template load when websocket is still connecting", () => {
+    const { result } = renderHook(() =>
+      useCanvasPipelineDerived({
+        readOnly: false,
+        pipeline: {
+          currentStage: "completed",
+          isGenerating: false,
+          isChatStreaming: false,
+          manualTerraformRunState: "idle",
+          messages: [],
+          streamingAssistantReply: "",
+          wsState: "connecting",
+        } as any,
+        diagram: {
+          nodes: [
+            { id: "vpc", data: { label: "VPC", category: "network" } },
+            { id: "alb", data: { label: "Load Balancer", category: "compute" } },
+          ],
+          selectedNodeIds: [],
+          canonicalNodes: [
+            { id: "vpc", data: { label: "VPC", category: "network" } },
+            { id: "alb", data: { label: "Load Balancer", category: "compute" } },
+          ],
+        } as any,
+        canvasSession: {
+          mode: "existing",
+          project: {
+            id: "proj-template-clone",
+            generationStage: "completed",
+          },
+        } as any,
+      })
+    );
+
+    expect(result.current.canvasHasArchitecture).toBe(true);
+    expect(result.current.chatEnabled).toBe(false);
+    expect(result.current.chatDisabledReason).toBe("Reconnecting to live session...");
+  });
+
+  it("enables chat once websocket opens after template load", () => {
+    const { result } = renderHook(() =>
+      useCanvasPipelineDerived({
+        readOnly: false,
+        pipeline: {
+          currentStage: "completed",
+          isGenerating: false,
+          isChatStreaming: false,
+          manualTerraformRunState: "idle",
+          messages: [],
+          streamingAssistantReply: "",
+          wsState: "open",
+        } as any,
+        diagram: {
+          nodes: [
+            { id: "vpc", data: { label: "VPC", category: "network" } },
+            { id: "alb", data: { label: "Load Balancer", category: "compute" } },
+          ],
+          selectedNodeIds: [],
+          canonicalNodes: [
+            { id: "vpc", data: { label: "VPC", category: "network" } },
+            { id: "alb", data: { label: "Load Balancer", category: "compute" } },
+          ],
+        } as any,
+        canvasSession: {
+          mode: "existing",
+          project: {
+            id: "proj-template-clone",
+            generationStage: "completed",
+          },
+        } as any,
+      })
+    );
+
+    expect(result.current.canvasHasArchitecture).toBe(true);
+    expect(result.current.chatEnabled).toBe(true);
+    expect(result.current.chatDisabledReason).toBeNull();
+  });
+});

--- a/frontend/lib/__tests__/useWebSocketConnection.test.ts
+++ b/frontend/lib/__tests__/useWebSocketConnection.test.ts
@@ -138,4 +138,42 @@ describe("useWebSocketConnection", () => {
 
     expect(wsClient.reconnect).toHaveBeenCalledTimes(1);
   });
+
+  it("queues project subscription and replays when connection opens", async () => {
+    let stateHandler: ((state: string) => void) | null = null;
+
+    vi.mocked(wsClient.onConnectionState).mockImplementation((handler) => {
+      stateHandler = handler;
+      handler("idle");
+      return () => {};
+    });
+
+    const desiredRef = { current: null as string | null };
+
+    const { result } = renderHook(() =>
+      useWebSocketConnection({
+        enabled: true,
+        onMessage: () => {},
+        desiredProjectSubscriptionRef: desiredRef,
+      })
+    );
+
+    act(() => {
+      result.current.queueProjectSubscription("proj-queued");
+    });
+
+    expect(desiredRef.current).toBe("proj-queued");
+
+    // Simulate connection opening
+    act(() => {
+      stateHandler?.("open");
+    });
+
+    // Wait for the async subscribeProject microtask
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(wsClient.send).toHaveBeenCalled();
+  });
 });

--- a/frontend/lib/__tests__/websocket.test.ts
+++ b/frontend/lib/__tests__/websocket.test.ts
@@ -101,3 +101,85 @@ describe("WebSocketClient heartbeat", () => {
     client.disconnect();
   });
 });
+
+describe("WebSocketClient sendWhenOpen", () => {
+  const originalWebSocket = globalThis.WebSocket;
+  let sockets: FakeWebSocket[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sockets = [];
+    class MockSocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    }
+    globalThis.WebSocket = MockSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+  });
+
+  it("sends immediately when socket is already open", async () => {
+    const client = new WebSocketClient();
+    client.connect();
+    sockets[0].open();
+
+    const promise = client.sendWhenOpen({ type: "chat", message: "hello" });
+    await expect(promise).resolves.toBe(true);
+    expect(sockets[0].sent).toHaveLength(1);
+    expect(JSON.parse(sockets[0].sent[0])).toEqual({ type: "chat", message: "hello" });
+    client.disconnect();
+  });
+
+  it("sends once the socket opens if currently connecting", async () => {
+    const client = new WebSocketClient();
+    client.connect();
+    expect(sockets[0].readyState).toBe(FakeWebSocket.CONNECTING);
+
+    const promise = client.sendWhenOpen({ type: "chat", message: "delayed" });
+
+    vi.advanceTimersByTime(2_000);
+    sockets[0].open();
+
+    await expect(promise).resolves.toBe(true);
+    expect(sockets[0].sent).toHaveLength(1);
+    expect(JSON.parse(sockets[0].sent[0])).toEqual({ type: "chat", message: "delayed" });
+    client.disconnect();
+  });
+
+  it("rejects if socket does not open before timeout", async () => {
+    const client = new WebSocketClient();
+    client.connect();
+
+    const promise = client.sendWhenOpen({ type: "chat", message: "timeout" }, 5_000);
+
+    vi.advanceTimersByTime(5_000);
+
+    await expect(promise).rejects.toThrow("WebSocket send timed out waiting for connection to open");
+    client.disconnect();
+  });
+
+  it("does not double-send if socket opens twice", async () => {
+    const client = new WebSocketClient();
+    client.connect();
+
+    const promise = client.sendWhenOpen({ type: "chat", message: "once" });
+
+    vi.advanceTimersByTime(1_000);
+    sockets[0].open();
+
+    await expect(promise).resolves.toBe(true);
+
+    // Simulate reconnect (new socket)
+    client.reconnect();
+    sockets[1].open();
+
+    expect(sockets[0].sent).toHaveLength(1);
+    client.disconnect();
+  });
+});

--- a/frontend/lib/canvasActions/useChatSendActions.ts
+++ b/frontend/lib/canvasActions/useChatSendActions.ts
@@ -113,11 +113,7 @@ export function useChatSendActions({
             edges: diagram.edges,
           })
         );
-        const sent = wsClient.send(payload);
-        if (!sent) {
-          failChatRequest("Connection lost while sending chat request.");
-          return;
-        }
+        await wsClient.sendWhenOpen(payload, 10_000);
         armChatResponseTimeout();
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Failed to send chat request.";

--- a/frontend/lib/useCanvasPipelineDerived.ts
+++ b/frontend/lib/useCanvasPipelineDerived.ts
@@ -3,6 +3,7 @@ import { hasArchitecture } from "./canvasInteractionGuards";
 import type { PipelineState } from "./usePipelineState";
 import type { DiagramState } from "./useDiagramState";
 import type { CanvasSession } from "./projects";
+import type { ConnectionState } from "./websocket";
 
 export function useCanvasPipelineDerived({
   readOnly,
@@ -18,8 +19,19 @@ export function useCanvasPipelineDerived({
   const activeProjectId = canvasSession?.mode === "existing" ? canvasSession.project.id : canvasSession?.mode === "new" ? canvasSession.projectId ?? null : null;
   const generationCompleted = pipeline.currentStage === "completed" || (canvasSession?.mode === "existing" && canvasSession.project.generationStage === "completed");
   const canvasHasArchitecture = hasArchitecture(diagram.nodes);
-  const chatEnabled = !readOnly && !pipeline.isGenerating && !pipeline.isChatStreaming;
-  const chatDisabledReason = readOnly ? "Read-only shared view." : !activeProjectId ? null : pipeline.isGenerating ? "Chat unlocks once generation is completed." : pipeline.isChatStreaming ? "Assistant is replying..." : null;
+  const wsReady = pipeline.wsState === "open";
+  const chatEnabled = !readOnly && !pipeline.isGenerating && !pipeline.isChatStreaming && wsReady;
+  const chatDisabledReason = readOnly
+    ? "Read-only shared view."
+    : !activeProjectId
+      ? null
+      : pipeline.isGenerating
+        ? "Chat unlocks once generation is completed."
+        : pipeline.isChatStreaming
+          ? "Assistant is replying..."
+          : !wsReady
+            ? "Reconnecting to live session..."
+            : null;
   const displayedMessages = pipeline.streamingAssistantReply
     ? [...pipeline.messages, { role: "assistant" as const, content: pipeline.streamingAssistantReply }]
     : pipeline.messages;

--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -126,6 +126,42 @@ export class WebSocketClient {
     return true;
   }
 
+  /** Send a message once the connection is open, or reject after timeout. */
+  sendWhenOpen(payload: unknown, timeoutMs = 10_000): Promise<boolean> {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+      return Promise.resolve(true);
+    }
+
+    return new Promise((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      };
+
+      const handler = () => {
+        cleanup();
+        if (this.ws?.readyState === WebSocket.OPEN) {
+          this.ws.send(JSON.stringify(payload));
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      };
+
+      timer = setTimeout(() => {
+        cleanupOpenHandler();
+        reject(new Error("WebSocket send timed out waiting for connection to open"));
+      }, timeoutMs);
+
+      const cleanupOpenHandler = this.onOpen(handler);
+    });
+  }
+
   onMessage(handler: MessageHandler) {
     this.handlers.push(handler);
     return () => {


### PR DESCRIPTION
Closes #239

## Summary

Fixes the race condition where chat messages are dropped when the websocket is still connecting, particularly after loading a template.

## Changes

1. **feat(websocket): add `sendWhenOpen` for reliable chat delivery when socket is connecting**
   - New `sendWhenOpen(payload, timeoutMs?)` method on `WebSocketClient`
   - If socket is already open, sends immediately
   - If socket is connecting, waits for open event and then sends
   - Rejects with clear error message on timeout

2. **feat(chat): use `sendWhenOpen` for chat to avoid drops during reconnect**
   - Chat send path now uses `sendWhenOpen` instead of fire-and-forget `send`
   - Preserves existing project bootstrap flow
   - Failure paths remain the same but with clearer reconnect-oriented messaging

3. **feat(chat): gate chat availability on websocket state and show reconnect reason**
   - `chatEnabled` now requires `wsState === "open"`
   - Shows "Reconnecting to live session..." disabled reason when socket is not ready
   - Prevents users from attempting to chat while connection is still establishing

4. **test(template-chat): add regression test for chat disabled during ws connect**
   - Verifies chat is disabled immediately after template load when websocket is still connecting
   - Verifies chat becomes enabled once websocket opens

5. **test(ws-connection): add subscription replay coverage for pre-open queue**
   - Ensures project subscription is replayed when queued before websocket open

## Testing

- All 449 existing frontend tests pass
- 10 new tests added across websocket, canvas actions, derived state, and regression suites

## Root Cause

Template cloning redirects users into a completed project where chat becomes available before the websocket is fully open. The chat send path had no retry/queue logic, causing the first message to be silently dropped with `WS not open, message dropped`.